### PR TITLE
set python to specific version on git-actions

### DIFF
--- a/.github/workflows/check-linting.yml
+++ b/.github/workflows/check-linting.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-            python-version: '3.7.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+            python-version: '3.7.5' # Version range or exact version of a Python version to use, using SemVer's version range syntax
             architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
 
       - name: Create Virtual Environment

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-            python-version: '3.7.x' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+            python-version: '3.7.5' # Version range or exact version of a Python version to use, using SemVer's version range syntax
             architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
   
       - name: Set up database


### PR DESCRIPTION
Similar tests in all APIs began failing recently without any related changes in code or tests.
This might be because of the new [python version 3.7.10](https://docs.python.org/release/3.7.10/)  released on February 15, 2021.

Before: on git actions we had specified python version as 3.7.x
Changed it to: 3.7.5
