### PR TITLE
Input bibles as json too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ vachan-venv/*
 vachan-ENV/*
 app/models/*
 temp.usfm
+temp.json

--- a/app/crud/utils.py
+++ b/app/crud/utils.py
@@ -138,6 +138,22 @@ def parse_usfm(usfm_string):
     usfm_json = json.loads(stdout.decode('utf-8'))
     return usfm_json
 
+def form_usfm(json_obj):
+    '''convert a usfm-grammar format JSON into usfm'''
+    file = open("temp.json", "w")
+    json.dump(json_obj, file)
+    # file.write(json_obj)
+    file.close()
+    process = subprocess.Popen(['usfm-grammar --output=usfm temp.json'],
+                         stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE,
+                         shell=True)
+    stdout, stderr = process.communicate()
+    if stderr:
+        raise TypeException(stderr.decode('utf-8'))
+    usfm_string = stdout.decode('utf-8')
+    return usfm_string
+
 
 def to_eng(data):
     '''Convert to roman/english script.


### PR DESCRIPTION
fixes #150 
as we decided to allow json uploading also, now we can upload a bible via providing
- usfm alone
- json(in the format given by usfm-grammar) alone
- both usfm and json

uses usfm-grammar at server side to obtain the missing format and saves both usfm and json in DB