### PR TITLE
Bugfix/graphql tests commiting to db

### DIFF
--- a/app/'
+++ b/app/'
@@ -1,1 +1,0 @@
-Unable to initialize device PRN

--- a/app/graphql_api/__init__.py
+++ b/app/graphql_api/__init__.py
@@ -3,6 +3,9 @@ from fastapi import APIRouter, Depends
 import graphene
 from starlette.requests import Request
 from starlette.graphql import GraphQLApp
+
+#pylint: disable=E0401
+#pylint gives import error if relative import is not used. But app(uvicorn) doesn't accept it
 from graphql_api import queries, mutations
 from dependencies import get_db
 

--- a/app/graphql_api/__init__.py
+++ b/app/graphql_api/__init__.py
@@ -1,1 +1,24 @@
-'''empty file to show this is a sub module'''
+'''defines the graphql router'''
+from fastapi import APIRouter, Depends
+import graphene
+from starlette.requests import Request
+from starlette.graphql import GraphQLApp
+from graphql_api import queries, mutations
+from dependencies import get_db
+
+router = APIRouter()
+
+schema=graphene.Schema(query=queries.Query,mutation=mutations.VachanMutations)
+graphql_app = GraphQLApp(schema)
+
+@router.post('/graphql')
+async def single_endpoint(request: Request, db_session=Depends(get_db)):
+    '''One endpoint for all graphql operations'''
+    request.db_session = db_session
+    return await graphql_app.handle_graphql(request=request)
+
+@router.get('/graphql')
+async def graphiql(request: Request, db_session=Depends(get_db)):
+    '''Get endpoint for graphiQL interface'''
+    request.db_session = db_session
+    return await graphql_app.handle_graphql(request=request)

--- a/app/graphql_api/queries.py
+++ b/app/graphql_api/queries.py
@@ -333,7 +333,7 @@ class Query(graphene.ObjectType):
     convert_to_usfm = graphene.List(graphene.String,
         description="Converts drafts to usfm",
         sentence_list=graphene.List(types.SentenceInput, required=True))
-    def resolve_convert_to_usfm(self, info, sentence_list):
+    def resolve_convert_to_usfm(self, _, sentence_list):
         '''resolver'''
         new_list = [ utils.convert_graphene_obj_to_pydantic(item, schemas_nlp.DraftInput)
                 for item in sentence_list]
@@ -343,7 +343,7 @@ class Query(graphene.ObjectType):
     convert_to_alignment = graphene.Field(types.Metadata,
         description="Converts sentences and drafts to alignment-json",
         sentence_list=graphene.List(types.SentenceInput, required=True))
-    def resolve_convert_to_alignment(self, info, sentence_list):
+    def resolve_convert_to_alignment(self, _, sentence_list):
         '''resolver'''
         new_list = [ utils.convert_graphene_obj_to_pydantic(item, schemas_nlp.DraftInput)
                 for item in sentence_list]
@@ -353,7 +353,7 @@ class Query(graphene.ObjectType):
     convert_to_csv = graphene.String(
         description="Converts sentences and drafts to CSV format",
         sentence_list=graphene.List(types.SentenceInput, required=True))
-    def resolve_convert_to_csv(self, info, sentence_list):
+    def resolve_convert_to_csv(self, _, sentence_list):
         '''resolver'''
         new_list = [ utils.convert_graphene_obj_to_pydantic(item, schemas_nlp.DraftInput)
                 for item in sentence_list]
@@ -363,7 +363,7 @@ class Query(graphene.ObjectType):
     convert_to_text = graphene.String(
         description="Converts drafts to alignment-json",
         sentence_list=graphene.List(types.SentenceInput, required=True))
-    def resolve_convert_to_text(self, info, sentence_list):
+    def resolve_convert_to_text(self, _, sentence_list):
         '''resolver'''
         new_list = [ utils.convert_graphene_obj_to_pydantic(item, schemas_nlp.DraftInput)
                 for item in sentence_list]

--- a/app/graphql_api/queries.py
+++ b/app/graphql_api/queries.py
@@ -4,9 +4,7 @@ import graphene
 
 #pylint: disable=E0401
 #pylint gives import error if relative import is not used. But app(uvicorn) doesn't accept it
-
 from crud import structurals_crud, contents_crud, projects_crud, nlp_crud
-from dependencies import get_db
 from graphql_api import types, utils
 import schemas_nlp
 
@@ -21,10 +19,11 @@ class Query(graphene.ObjectType):
         language_name=graphene.String(), language_code=graphene.String(
             description="language code as per bcp47(usually 2 letter code)"),
         skip=graphene.Int(), limit=graphene.Int())
-    def resolve_languages(self, _,
+    def resolve_languages(self, info,
         search_word=None, language_code=None, language_name=None,
-        skip=0, limit=100, db_=next(get_db())):
+        skip=0, limit=100):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return structurals_crud.get_languages(db_, language_code=language_code,
             language_name=language_name, search_word=search_word,
             skip=skip, limit=limit)
@@ -33,19 +32,21 @@ class Query(graphene.ObjectType):
         description="Query supported content types in vachan-db",
         content_type=graphene.String(),
         skip=graphene.Int(), limit=graphene.Int())
-    def resolve_content_types(self, _, content_type=None,
-        skip=0, limit=100, db_=next(get_db())):
+    def resolve_content_types(self, info, content_type=None,
+        skip=0, limit=100):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return structurals_crud.get_content_types(db_, content_type, skip, limit)
 
     licenses = graphene.List(types.License,
         description="Query uploaded licenses in vachan-db", license_code=graphene.String(),
         license_name=graphene.String(), permission=types.LicensePermission(),
         active=graphene.Boolean(), skip=graphene.Int(), limit=graphene.Int())
-    def resolve_licenses(self, _, license_code=None, license_name=None,
+    def resolve_licenses(self, info, license_code=None, license_name=None,
         permission=None, active=True,
-        skip=0, limit=100, db_=next(get_db())):
+        skip=0, limit=100):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return structurals_crud.get_licenses(db_, license_code, license_name, permission,
         active, skip = skip, limit = limit)
 
@@ -53,9 +54,10 @@ class Query(graphene.ObjectType):
         description="Query defined versions in vachan-db", version_abbreviation=graphene.String(),
         version_name=graphene.String(), revision=graphene.Int(),
         skip=graphene.Int(), limit=graphene.Int())
-    def resolve_versions(self, _, version_abbreviation=None, version_name=None,
-        revision=None, skip=0, limit=100, db_=next(get_db())):
+    def resolve_versions(self, info, version_abbreviation=None, version_name=None,
+        revision=None, skip=0, limit=100):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return structurals_crud.get_versions(db_, version_abbreviation,
         version_name, revision, skip = skip, limit = limit)
 
@@ -67,10 +69,11 @@ class Query(graphene.ObjectType):
         license_code=graphene.String(),
         active=graphene.Boolean(), latest_revision=graphene.Boolean(),
         skip=graphene.Int(), limit=graphene.Int())
-    def resolve_contents(self, _, content_type=None, version_abbreviation=None,
+    def resolve_contents(self, info, content_type=None, version_abbreviation=None,
         revision=None, language_code=None, license_code=None, active=True,
-        latest_revision=True, skip=0, limit=100, db_=next(get_db())):
+        latest_revision=True, skip=0, limit=100):
         '''resolver'''
+        db_ = info.context["request"].db_session
         results =  structurals_crud.get_sources(db_, content_type, version_abbreviation, revision,
             language_code, license_code, latest_revision=latest_revision, active=active,
             skip=skip, limit=limit)
@@ -81,9 +84,10 @@ class Query(graphene.ObjectType):
         book_code=graphene.String(description="3 letter code like, gen, mat etc"),
         book_name=graphene.String(),
         skip=graphene.Int(), limit=graphene.Int())
-    def resolve_bible_books(self, _, book_id=None, book_name=None,
-        book_code=None, skip=0, limit=100, db_=next(get_db())):
+    def resolve_bible_books(self, info, book_id=None, book_name=None,
+        book_code=None, skip=0, limit=100):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return structurals_crud.get_bible_books(db_, book_id=book_id,
             book_code=book_code, book_name=book_name, skip=skip, limit=limit)
 
@@ -94,9 +98,10 @@ class Query(graphene.ObjectType):
         chapter=graphene.Int(), verse=graphene.Int(),
         last_verse=graphene.Int(), active=graphene.Boolean(),
         skip=graphene.Int(), limit=graphene.Int())
-    def resolve_commentaries(self, _, source_name, book_code=None, chapter=None,
-        verse=None, last_verse=None, active=True, skip=0, limit=100, db_=next(get_db())):
+    def resolve_commentaries(self, info, source_name, book_code=None, chapter=None,
+        verse=None, last_verse=None, active=True, skip=0, limit=100):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return contents_crud.get_commentaries(db_, source_name, book_code, chapter, verse,
             last_verse, active=active, skip = skip, limit = limit)
 
@@ -105,9 +110,10 @@ class Query(graphene.ObjectType):
         source_name=graphene.String(required=True),
         search_word=graphene.String(), exact_match=graphene.Boolean(), active=graphene.Boolean(),
         skip=graphene.Int(), limit=graphene.Int())
-    def resolve_dictonary_words(self, _, source_name, search_word=None, exact_match=False,
-        active=True, skip=0, limit=100, db_=next(get_db())):
+    def resolve_dictonary_words(self, info, source_name, search_word=None, exact_match=False,
+        active=True, skip=0, limit=100):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return contents_crud.get_dictionary_words(db_, source_name, search_word,
             exact_match=exact_match, active=active, skip=skip, limit=limit)
 
@@ -116,9 +122,10 @@ class Query(graphene.ObjectType):
         book_code=graphene.String(description="3 letter code like, gen, mat etc"),
         title=graphene.String(), active=graphene.Boolean(),
         skip=graphene.Int(), limit=graphene.Int())
-    def resolve_infographics(self, _, source_name, book_code=None, title=None, active=True,
-        skip=0, limit=100, db_=next(get_db())):
+    def resolve_infographics(self, info, source_name, book_code=None, title=None, active=True,
+        skip=0, limit=100):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return contents_crud.get_infographics(db_, source_name, book_code, title,
          active=active, skip = skip, limit = limit)
 
@@ -128,9 +135,10 @@ class Query(graphene.ObjectType):
         book_code=graphene.String(description="3 letter code like, gen, mat etc"),
         title=graphene.String(), theme=graphene.String(),
         active=graphene.Boolean(), skip=graphene.Int(), limit=graphene.Int())
-    def resolve_bible_videos(self, _, source_name, book_code=None, title=None, theme=None,
-        active=True, skip=0, limit=100, db_=next(get_db())):
+    def resolve_bible_videos(self, info, source_name, book_code=None, title=None, theme=None,
+        active=True, skip=0, limit=100):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return contents_crud.get_bible_videos(db_, source_name, book_code, title, theme, active,
             skip=skip, limit=limit)
 
@@ -139,17 +147,19 @@ class Query(graphene.ObjectType):
         source_name=graphene.String(required=True),
         book_code=graphene.String(description="3 letter code like, gen, mat etc"),
         active=graphene.Boolean(), skip=graphene.Int(), limit=graphene.Int())
-    def resolve_bible_contents(self, _, source_name, book_code=None, active=True,
-        skip=0, limit=100, db_=next(get_db())):
+    def resolve_bible_contents(self, info, source_name, book_code=None, active=True,
+        skip=0, limit=100):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return contents_crud.get_available_bible_books(db_, source_name, book_code,
             content_type="all", active=active, skip = skip, limit = limit)
 
     versification = graphene.Field(types.Versification,
         description="Query versification structure of a bible in vachan-db",
         source_name=graphene.String(required=True))
-    def resolve_versification(self, _, source_name, db_=next(get_db())):
+    def resolve_versification(self, info, source_name):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return contents_crud.get_bible_versification(db_, source_name)
 
     bible_verse = graphene.List(types.BibleVerse,
@@ -159,9 +169,10 @@ class Query(graphene.ObjectType):
         chapter=graphene.Int(), verse=graphene.Int(),
         last_verse=graphene.Int(), search_phrase=graphene.String(), active=graphene.Boolean(),
         skip=graphene.Int(), limit=graphene.Int())
-    def resolve_bible_verse(self, _, source_name, book_code=None, chapter=None, verse=None,
-        last_verse=None, search_phrase=None, active=True, skip=0, limit=100, db_=next(get_db())):
+    def resolve_bible_verse(self, info, source_name, book_code=None, chapter=None, verse=None,
+        last_verse=None, search_phrase=None, active=True, skip=0, limit=100):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return contents_crud.get_bible_verses(db_, source_name, book_code, chapter, verse,
             last_verse, search_phrase, active=active, skip = skip, limit = limit)
 
@@ -173,10 +184,11 @@ class Query(graphene.ObjectType):
             description="language code as per bcp47(usually 2 letters)"),
         user_id=graphene.Int(), active=graphene.Boolean(),
         skip=graphene.Int(), limit=graphene.Int())
-    def resolve_agmt_projects(self, _, project_name=None,
+    def resolve_agmt_projects(self, info, project_name=None,
         source_language=None, target_language=None, user_id=None, active=True,
-        skip=0, limit=100, db_=next(get_db())):
+        skip=0, limit=100):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return projects_crud.get_agmt_projects(db_, project_name, source_language, target_language,
             active, user_id, skip=skip, limit=limit)
 
@@ -188,10 +200,11 @@ class Query(graphene.ObjectType):
         description="Requires exactly two numbers indicating a range"),
         sentence_id_list=graphene.List(graphene.Int), use_translation_memory=graphene.Boolean(),
         include_phrases=graphene.Boolean(), include_stopwords=graphene.Boolean())
-    def resolve_agmt_project_tokens(self, _, project_id, books=None, sentence_id_range=None,
+    def resolve_agmt_project_tokens(self, info, project_id, books=None, sentence_id_range=None,
         sentence_id_list=None, use_translation_memory=True, include_phrases=True,
-        include_stopwords=False, db_=next(get_db())):
+        include_stopwords=False):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return nlp_crud.get_agmt_tokens(db_, project_id, books, sentence_id_range, sentence_id_list,
             use_translation_memory, include_phrases, include_stopwords)
 
@@ -200,9 +213,9 @@ class Query(graphene.ObjectType):
         project_id=graphene.ID(required=True), sentence_id=graphene.Int(required=True),
         offset=graphene.List(graphene.Int, required=True,
         description="Requires exactly two numbers"))
-    def resolve_agmt_project_token_translation(self, _, project_id, sentence_id, offset,
-        db_=next(get_db())):
+    def resolve_agmt_project_token_translation(self, info, project_id, sentence_id, offset):
         '''resolver'''
+        db_ = info.context["request"].db_session
         occurrences = [{"sentenceId":sentence_id, "offset":offset}]
         return projects_crud.obtain_agmt_token_translation(db_, project_id, token=None,
             occurrences=occurrences)[0]
@@ -214,9 +227,10 @@ class Query(graphene.ObjectType):
         sentence_id_list=graphene.List(graphene.Int),
         sentence_id_range=graphene.List(graphene.Int,
             description='Requires exactly two numbers indicating a range'))
-    def resolve_agmt_draft_usfm(self, _, project_id, books=None, sentence_id_list=None,
-        sentence_id_range=None, db_=next(get_db())):
+    def resolve_agmt_draft_usfm(self, info, project_id, books=None, sentence_id_list=None,
+        sentence_id_range=None):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return projects_crud.obtain_agmt_draft(db_, project_id, books,
             sentence_id_list, sentence_id_range, output_format=schemas_nlp.DraftFormats.USFM)
 
@@ -227,9 +241,10 @@ class Query(graphene.ObjectType):
         sentence_id_list=graphene.List(graphene.Int),
         sentence_id_range=graphene.List(graphene.Int,
             description='Requires exactly two numbers indicating a range'))
-    def resolve_agmt_export_alignment(self, _, project_id, books=None, sentence_id_list=None,
-        sentence_id_range=None, db_=next(get_db())):
+    def resolve_agmt_export_alignment(self, info, project_id, books=None, sentence_id_list=None,
+        sentence_id_range=None):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return projects_crud.obtain_agmt_draft(db_, project_id, books,
             sentence_id_list, sentence_id_range, output_format=schemas_nlp.DraftFormats.JSON)
 
@@ -240,9 +255,10 @@ class Query(graphene.ObjectType):
         sentence_id_list=graphene.List(graphene.Int),
         sentence_id_range=graphene.List(graphene.Int,
             description='Requires exactly two numbers indicating a range'))
-    def resolve_agmt_project_source(self, _, project_id, books=None, sentence_id_list=None,
-        sentence_id_range=None, db_=next(get_db())):
+    def resolve_agmt_project_source(self, info, project_id, books=None, sentence_id_list=None,
+        sentence_id_range=None):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return nlp_crud.obtain_agmt_source(db_, project_id, books, sentence_id_list,
             sentence_id_range, with_draft=True)
 
@@ -253,9 +269,10 @@ class Query(graphene.ObjectType):
         sentence_id_list=graphene.List(graphene.Int),
         sentence_id_range=graphene.List(graphene.Int,
             description='Requires exactly two numbers indicating a range'))
-    def resolve_agmt_project_progress(self, _, project_id, books=None, sentence_id_list=None,
-        sentence_id_range=None, db_=next(get_db())):
+    def resolve_agmt_project_progress(self, info, project_id, books=None, sentence_id_list=None,
+        sentence_id_range=None):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return projects_crud.obtain_agmt_progress(db_, project_id, books,
             sentence_id_list, sentence_id_range)
 
@@ -268,9 +285,10 @@ class Query(graphene.ObjectType):
         token=graphene.String(required=True),
         context=graphene.String(description="sentence or phrase including the token"),
         token_offset=graphene.List(graphene.Int, description="Requires exactly two numbers"))
-    def resolve_gloss(self, _, source_language, target_language, token, context=None,
-        token_offset=None, db_=next(get_db())):
+    def resolve_gloss(self, info, source_language, target_language, token, context=None,
+        token_offset=None):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return nlp_crud.glossary(db_, source_language, target_language, token,context,token_offset)
 
     tokenize = graphene.List(types.Token,
@@ -283,11 +301,11 @@ class Query(graphene.ObjectType):
         use_translation_memory=graphene.Boolean(), include_phrases=graphene.Boolean(),
         include_stopwords=graphene.Boolean(), punctuations=graphene.List(graphene.String),
         stopwords=graphene.Argument(types.Stopwords))
-    def resolve_tokenize(self, _, source_language, sentence_list, target_language=None,
+    def resolve_tokenize(self, info, source_language, sentence_list, target_language=None,
             use_translation_memory=True, include_phrases=True,
-            include_stopwords=False, punctuations=None, stopwords=None,
-            db_=next(get_db())):
+            include_stopwords=False, punctuations=None, stopwords=None):
         '''resolver'''
+        db_ = info.context["request"].db_session
         return nlp_crud.get_generic_tokens(db_, source_language, sentence_list, target_language,
             punctuations, stopwords, use_translation_memory, include_phrases, include_stopwords)
 
@@ -300,9 +318,10 @@ class Query(graphene.ObjectType):
         sentence_list=graphene.List(types.SentenceInput, required=True),
         token_translations=graphene.List(types.TokenUpdate, required=True),
         use_data_for_learning=graphene.Boolean())
-    def resolve_translate_token(self, _, source_language, target_language, sentence_list,
-        token_translations, use_data_for_learning=True, db_=next(get_db())):
+    def resolve_translate_token(self, info, source_language, target_language, sentence_list,
+        token_translations, use_data_for_learning=True):
         '''resolver'''
+        db_ = info.context["request"].db_session
         new_sent_list = [ utils.convert_graphene_obj_to_pydantic(item, schemas_nlp.DraftInput)
                 for item in sentence_list]
         new_token_list =[ utils.convert_graphene_obj_to_pydantic(item, schemas_nlp.TokenUpdate)
@@ -314,8 +333,9 @@ class Query(graphene.ObjectType):
     convert_to_usfm = graphene.List(graphene.String,
         description="Converts drafts to usfm",
         sentence_list=graphene.List(types.SentenceInput, required=True))
-    def resolve_convert_to_usfm(self, _, sentence_list):
+    def resolve_convert_to_usfm(self, info, sentence_list):
         '''resolver'''
+        db_ = info.context["request"].db_session
         new_list = [ utils.convert_graphene_obj_to_pydantic(item, schemas_nlp.DraftInput)
                 for item in sentence_list]
         return nlp_crud.obtain_draft(new_list,
@@ -324,8 +344,9 @@ class Query(graphene.ObjectType):
     convert_to_alignment = graphene.Field(types.Metadata,
         description="Converts sentences and drafts to alignment-json",
         sentence_list=graphene.List(types.SentenceInput, required=True))
-    def resolve_convert_to_alignment(self, _, sentence_list):
+    def resolve_convert_to_alignment(self, info, sentence_list):
         '''resolver'''
+        db_ = info.context["request"].db_session
         new_list = [ utils.convert_graphene_obj_to_pydantic(item, schemas_nlp.DraftInput)
                 for item in sentence_list]
         return nlp_crud.obtain_draft(new_list,
@@ -334,8 +355,9 @@ class Query(graphene.ObjectType):
     convert_to_csv = graphene.String(
         description="Converts sentences and drafts to CSV format",
         sentence_list=graphene.List(types.SentenceInput, required=True))
-    def resolve_convert_to_csv(self, _, sentence_list):
+    def resolve_convert_to_csv(self, info, sentence_list):
         '''resolver'''
+        db_ = info.context["request"].db_session
         new_list = [ utils.convert_graphene_obj_to_pydantic(item, schemas_nlp.DraftInput)
                 for item in sentence_list]
         return nlp_crud.obtain_draft(new_list,
@@ -344,8 +366,9 @@ class Query(graphene.ObjectType):
     convert_to_text = graphene.String(
         description="Converts drafts to alignment-json",
         sentence_list=graphene.List(types.SentenceInput, required=True))
-    def resolve_convert_to_text(self, _, sentence_list):
+    def resolve_convert_to_text(self, info, sentence_list):
         '''resolver'''
+        db_ = info.context["request"].db_session
         new_list = [ utils.convert_graphene_obj_to_pydantic(item, schemas_nlp.DraftInput)
                 for item in sentence_list]
         return nlp_crud.obtain_draft(new_list,

--- a/app/graphql_api/queries.py
+++ b/app/graphql_api/queries.py
@@ -335,7 +335,6 @@ class Query(graphene.ObjectType):
         sentence_list=graphene.List(types.SentenceInput, required=True))
     def resolve_convert_to_usfm(self, info, sentence_list):
         '''resolver'''
-        db_ = info.context["request"].db_session
         new_list = [ utils.convert_graphene_obj_to_pydantic(item, schemas_nlp.DraftInput)
                 for item in sentence_list]
         return nlp_crud.obtain_draft(new_list,
@@ -346,7 +345,6 @@ class Query(graphene.ObjectType):
         sentence_list=graphene.List(types.SentenceInput, required=True))
     def resolve_convert_to_alignment(self, info, sentence_list):
         '''resolver'''
-        db_ = info.context["request"].db_session
         new_list = [ utils.convert_graphene_obj_to_pydantic(item, schemas_nlp.DraftInput)
                 for item in sentence_list]
         return nlp_crud.obtain_draft(new_list,
@@ -357,7 +355,6 @@ class Query(graphene.ObjectType):
         sentence_list=graphene.List(types.SentenceInput, required=True))
     def resolve_convert_to_csv(self, info, sentence_list):
         '''resolver'''
-        db_ = info.context["request"].db_session
         new_list = [ utils.convert_graphene_obj_to_pydantic(item, schemas_nlp.DraftInput)
                 for item in sentence_list]
         return nlp_crud.obtain_draft(new_list,
@@ -368,7 +365,6 @@ class Query(graphene.ObjectType):
         sentence_list=graphene.List(types.SentenceInput, required=True))
     def resolve_convert_to_text(self, info, sentence_list):
         '''resolver'''
-        db_ = info.context["request"].db_session
         new_list = [ utils.convert_graphene_obj_to_pydantic(item, schemas_nlp.DraftInput)
                 for item in sentence_list]
         return nlp_crud.obtain_draft(new_list,

--- a/app/main.py
+++ b/app/main.py
@@ -5,10 +5,8 @@ from fastapi.responses import JSONResponse
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.exceptions import HTTPException as StarletteHTTPException
-from starlette.graphql import GraphQLApp
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError, IntegrityError
-import graphene
 
 
 #pylint: disable=E0401
@@ -21,7 +19,7 @@ from dependencies import get_db, log
 
 from schemas import NormalResponse
 from routers import content_apis, translation_apis
-from graphql_api import queries, mutations
+from graphql_api import router as gql_router
 
 app = FastAPI()
 app.add_middleware(
@@ -152,6 +150,4 @@ def test(db_: Session = Depends(get_db)):
 
 app.include_router(content_apis.router)
 app.include_router(translation_apis.router)
-
-schema=graphene.Schema(query=queries.Query,mutation=mutations.VachanMutations)
-app.add_route("/graphql", GraphQLApp(schema=schema))
+app.include_router(gql_router)

--- a/app/test/__init__.py
+++ b/app/test/__init__.py
@@ -1,6 +1,6 @@
 '''Set testing environment and define common tests'''
 from fastapi.testclient import TestClient
-from main import app
+from app.main import app
 
 client = TestClient(app)
 

--- a/app/test/__init__.py
+++ b/app/test/__init__.py
@@ -1,13 +1,20 @@
 '''Set testing environment and define common tests'''
-
-import os
-import sys
-import pytest
 from fastapi.testclient import TestClient
-
-from app.main import app, get_db, log
+from main import app
 
 client = TestClient(app)
+
+def gql_request(query, operation="query", variables=None):
+    '''common format for gql reqests with test db session in context'''
+    url = '/graphql'
+    post_body = {
+        "query": query,
+        "operation": operation,
+        "variables": variables
+    }
+    headers = {"contentType": "application/json", "accept": "application/json"}
+    response = client.post(url, headers=headers, json=post_body)
+    return response.json()
 
 def assert_input_validation_error(response):
     '''Check for input validation error in response'''

--- a/app/test/test_graphql_languages.py
+++ b/app/test/test_graphql_languages.py
@@ -1,22 +1,8 @@
 '''Test cases for language related GraphQL'''
-import os
-import sys
 from typing import Dict
-#pylint: disable=E0611
-#pylint: disable=E0401
-from test.test_languages import assert_positive_get
-from graphene.test import Client
-import graphene
-current_directory = os.path.dirname(os.path.realpath(__file__))
-parent_directory = os.path.dirname(current_directory)
-sys.path.append(parent_directory)
-#pylint: disable=C0413
-#pylint: disable=E0401
-from graphql_api import queries, mutations
 
-schema=graphene.Schema(query=queries.Query,mutation=mutations.VachanMutations)
-client = Client(schema)
-
+from . import gql_request
+from .test_languages import assert_positive_get
 
 def test_get_all_data():
     """test for get all data as per the following query"""
@@ -31,7 +17,7 @@ def test_get_all_data():
     }
     }
     """
-    executed = client.execute(default_get_query)
+    executed = gql_request(default_get_query)
     assert isinstance(executed, Dict)
     assert len(executed["data"]["languages"])>0
     assert isinstance(executed["data"]["languages"], list)
@@ -48,7 +34,7 @@ def test_get_one_language_with_argument():
     }
     }
     """
-    executed = client.execute(default_get_query)
+    executed = gql_request(default_get_query)
     assert executed == {"data": {"languages": [{"language": "Afar"}]}}
 
 
@@ -70,9 +56,9 @@ def test_check_gql_skip():
     }
     }
     """
-    executed = client.execute(query_skip0)
+    executed = gql_request(query_skip0)
     assert isinstance(executed, Dict)
     if len(executed["data"]["languages"]) > 1:
-        executed2 = client.execute(query_skip1)
+        executed2 = gql_request(query_skip1)
         assert isinstance(executed2, Dict)
         assert executed["data"]["languages"][1] == executed2["data"]["languages"][0]


### PR DESCRIPTION
Fixes #184 

The DB connection for REST apis are passed as Fastapi dependancy and is overriden by an alternate connection in testClient.

The graphene App or test Client doesn't have the concept of dependancies and hence it is hard to pass on the same.
This PR re-structures how grapheneApp is connected to the main fastAPI app. It is now following a method that is very close to the routers for REST and define a POST and GET endpoints for all the graphQL requests. These routers are taking the DB connection as a dependancy and passing it on to the graphene module as a request context which the graphene understand.
Doing this allows us to override the DB connection dependancy in Testclient.

This also includes changes to the graphQL tests as per this change in configuration. It doesn't use the graphene's test client or `execute` method for making gql requests. Instead gql queries are passed on as regular http POST requests to the endpoint `/graphql`
