### PR TITLE
Fix wrong SQL in tokenization

### DIFF
--- a/app/crud/nlp_crud.py
+++ b/app/crud/nlp_crud.py
@@ -726,7 +726,7 @@ def get_gloss(db_:Session, index, context, source_lang, target_lang): # pylint: 
         db_models.TranslationMemory.token,
         db_models.TranslationMemory.translation,
         db_models.TranslationMemory.frequency,
-        text("levenshtein(source_token,'%s') as lev_score"%word)
+        text("levenshtein(source_token,:word) as lev_score").bindparams(word=word)
         ).filter(
             db_models.TranslationMemory.source_language.has(code=source_lang),
             db_models.TranslationMemory.target_language.has(code=target_lang),
@@ -737,7 +737,7 @@ def get_gloss(db_:Session, index, context, source_lang, target_lang): # pylint: 
         db_models.TranslationMemory.translation,
         db_models.TranslationMemory.token,
         db_models.TranslationMemory.frequency,
-        text("levenshtein(translation,'%s') as lev_score"%word)
+        text("levenshtein(translation,:word) as lev_score").bindparams(word=word)
         ).filter(
             db_models.TranslationMemory.source_language.has(code=target_lang),
             db_models.TranslationMemory.target_language.has(code=source_lang),

--- a/app/crud/nlp_crud.py
+++ b/app/crud/nlp_crud.py
@@ -730,8 +730,9 @@ def get_gloss(db_:Session, index, context, source_lang, target_lang): # pylint: 
         ).filter(
             db_models.TranslationMemory.source_language.has(code=source_lang),
             db_models.TranslationMemory.target_language.has(code=target_lang),
-            text("soundex(source_token_romanized) = soundex('%s')"%utils.to_eng(word)),
-            text("levenshtein(source_token,'%s') < 4"%word))
+            text("soundex(source_token_romanized) = soundex(:word)").\
+                bindparams(word=utils.to_eng(word)),
+            text("levenshtein(source_token,:word) < 4").bindparams(word=word))
     reverse_query = db_.query(db_models.TranslationMemory).with_entities(
         db_models.TranslationMemory.translation,
         db_models.TranslationMemory.token,
@@ -740,8 +741,9 @@ def get_gloss(db_:Session, index, context, source_lang, target_lang): # pylint: 
         ).filter(
             db_models.TranslationMemory.source_language.has(code=target_lang),
             db_models.TranslationMemory.target_language.has(code=source_lang),
-            text("soundex(translation_romanized) = soundex('%s')"%utils.to_eng(word)),
-            text("levenshtein(translation,'%s') < 4"%word))
+            text("soundex(translation_romanized) = soundex(:word)").\
+                bindparams(word=utils.to_eng(word)),
+            text("levenshtein(translation,:word) < 4").bindparams(word=word))
     forward_dict_entires =  forward_query.all()
     reverse_dict_entires = reverse_query.all()
     for row in forward_dict_entires+ reverse_dict_entires:

--- a/app/crud/utils.py
+++ b/app/crud/utils.py
@@ -159,7 +159,7 @@ def to_eng(data):
     '''Convert to roman/english script.
     Not an acurate transliteration. But good enough for doing soundex'''
     data = normalize_unicode(data)
-    return unidecode(data).replace("'","")
+    return unidecode(data)
 
 def validate_language_tag(tag):
     '''uses an external service to validate newly added language sub tags'''

--- a/app/crud/utils.py
+++ b/app/crud/utils.py
@@ -159,7 +159,7 @@ def to_eng(data):
     '''Convert to roman/english script.
     Not an acurate transliteration. But good enough for doing soundex'''
     data = normalize_unicode(data)
-    return unidecode(data)
+    return unidecode(data).replace("'","")
 
 def validate_language_tag(tag):
     '''uses an external service to validate newly added language sub tags'''


### PR DESCRIPTION
fixes #216 

The syntax error given by the database was due to the apostrophe in the romanized word injected in the SQL query. 
As we require to run query using soundex, the ORM query builder's `text()` feature is used to inject this part of the query. The romanization library we use, unidecode, adds apostrophes(`'`) within words which was resulting in the error. 

In this fix we remove apostrophes from unidecode's response.