### PR TITLE
V2 role based access

### DIFF
--- a/app/authentication.py
+++ b/app/authentication.py
@@ -267,7 +267,8 @@ def filter_resource_content_get(db_resource, access_tags, required_permission, u
                 allowed_users = access_rules[tag][required_permission]
                 # print("ALLOWED USERS PERMISIONS=====>",tag,":=>",allowed_users)
                 role = "noAuthRequired"
-                if role in allowed_users:
+                if role in allowed_users and \
+                        not any(source == dic for dic in filtered_content):
                     filtered_content.append(source)
                 else:
                     for role in user_roles:

--- a/app/authentication.py
+++ b/app/authentication.py
@@ -249,14 +249,6 @@ def filter_resource_content_get(db_resource, access_tags, required_permission, u
     has_rights = False
     filtered_content = []
 
-    # if not recieve_token is None:
-    #     user_details = get_current_user_data(recieve_token)
-    #     if not 'error' in  user_details.keys():
-    #         user_id = user_details['user_id'] #pylint: disable=W0612  #use in future
-    #         user_roles = user_details['user_roles']
-    #         if 'APIUser' in user_roles:
-    #             user_roles.remove('APIUser')#pylint: disable=no-member #unwanted error
-    #             user_roles.append('registeredUser')#pylint: disable=no-member
     if not 'error' in  user_details.keys():
         user_id = user_details['user_id'] #pylint: disable=W0612  #use in future
         user_roles = user_details['user_roles']

--- a/app/authentication.py
+++ b/app/authentication.py
@@ -16,11 +16,11 @@ from custom_exceptions import GenericException ,\
 from api_permission_map import api_permission_map
 
 
-PUBLIC_BASE_URL = os.environ.get("VACHAN_KRATOS_PUBLIC_URL"+"self-service/",
-                                    "http://127.0.0.1:4433/self-service/")
+PUBLIC_BASE_URL = os.environ.get("VACHAN_KRATOS_PUBLIC_URL",
+                                    "http://127.0.0.1:4433/")+"self-service/"
 ADMIN_BASE_URL = os.environ.get("VACHAN_KRATOS_ADMIN_URL", "http://127.0.0.1:4434/")
-USER_SESSION_URL = os.environ.get("VACHAN_KRATOS_PUBLIC_URL"+ "sessions/whoami",
-                                "http://127.0.0.1:4433/sessions/whoami")
+USER_SESSION_URL = os.environ.get("VACHAN_KRATOS_PUBLIC_URL",
+                                "http://127.0.0.1:4433/")+ "sessions/whoami"
 SUPER_USER = os.environ.get("VACHAN_SUPER_USERNAME")
 SUPER_PASSWORD = os.environ.get("VACHAN_SUPER_PASSWORD")
 
@@ -354,6 +354,7 @@ def get_auth_access_check_decorator(func):
     """Decorator function for auth and access check for all routers"""
     @wraps(func)
     async def wrapper(*args, **kwargs):#pylint: disable=too-many-branches
+        # print("inside decorator===>")
         db_resource =None
         verified = False
         required_params = verify_auth_decorator_params(kwargs)

--- a/app/crud/structurals_crud.py
+++ b/app/crud/structurals_crud.py
@@ -184,7 +184,7 @@ def update_version(db_: Session, version: schemas.VersionEdit, user_id=None):
     # db_.refresh(db_content)
     return db_content
 
-def get_sources(db_: Session,#pylint: disable=too-many-locals,too-many-branches
+def get_sources(db_: Session,#pylint: disable=too-many-locals,too-many-branches,too-many-nested-blocks
     content_type=None, version_abbreviation=None, revision=None, language_code=None,
     **kwargs):
     '''Fetches the rows of sources table'''
@@ -240,7 +240,7 @@ def get_sources(db_: Session,#pylint: disable=too-many-locals,too-many-branches
     # Filtering out the latest versions here from the query result.
     # Had tried to include that into the query, but it seemed very difficult.
     latest_res = []
-    for res_item in res:
+    for res_item in res:#pylint: disable=too-many-nested-blocks
         exculde = False
         x_parts = res_item.sourceName.split('_')
         for latest_item in latest_res:

--- a/app/crud/structurals_crud.py
+++ b/app/crud/structurals_crud.py
@@ -190,6 +190,7 @@ def get_sources(db_: Session,#pylint: disable=too-many-locals,too-many-branches
     '''Fetches the rows of sources table'''
     license_abbreviation = kwargs.get("license_abbreviation",None)
     metadata = kwargs.get("metadata",None)
+    access_tags = kwargs.get("access_tag",None)
     latest_revision = kwargs.get("latest_revision",True)
     active = kwargs.get("active",True)
     source_name = kwargs.get("source_name",None)
@@ -249,7 +250,15 @@ def get_sources(db_: Session,#pylint: disable=too-many-locals,too-many-branches
                     exculde = True
                     break
         if not exculde:
-            latest_res.append(res_item)
+            #check for filter based on access tag
+            db_access_list = res_item.metaData['accessPermissions']
+            if not access_tags is None:
+                for check_tag in access_tags:
+                    if check_tag in db_access_list:
+                        if not res_item in latest_res:
+                            latest_res.append(res_item)
+            else:
+                latest_res.append(res_item)
     return latest_res
 
 def create_source(db_: Session, source: schemas.SourceCreate, source_name, user_id):

--- a/app/db_models.py
+++ b/app/db_models.py
@@ -8,6 +8,7 @@ from sqlalchemy.sql import func
 from sqlalchemy.orm import relationship, Session
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.schema import Sequence
+from sqlalchemy.dialects.postgresql import JSONB
 
 from database import Base
 from custom_exceptions import GenericException
@@ -92,7 +93,7 @@ class Source(Base): # pylint: disable=too-few-public-methods
     versionId = Column('version_id', Integer, ForeignKey('versions.version_id'))
     version = relationship('Version')
     active = Column('active', Boolean)
-    metaData = Column('metadata', JSON)
+    metaData = Column('metadata', JSONB)
     createdUser = Column('created_user', String)
     updatedUser = Column('last_updated_user', String)
     updateTime = Column('last_updated_at', DateTime, onupdate=func.now())

--- a/app/graphql_api/queries.py
+++ b/app/graphql_api/queries.py
@@ -4,8 +4,6 @@ import graphene
 from crud import structurals_crud, contents_crud, projects_crud, nlp_crud
 from graphql_api import types, utils
 import schemas_nlp
-from routers import content_apis
-from authentication import get_current_user_data
 
 #Pylint error :- Query class have all resolver functions
 #pylint: disable=R0201
@@ -49,7 +47,7 @@ class Query(graphene.ObjectType):
         # print("user_details===>",user_details)
         # return content_apis.get_language(req,language_code,language_name,
         # search_word,skip,limit,user_details,db_)
-        
+
         return structurals_crud.get_languages(db_, language_code=language_code,
             language_name=language_name, search_word=search_word,
             skip=skip, limit=limit)

--- a/app/graphql_api/queries.py
+++ b/app/graphql_api/queries.py
@@ -4,10 +4,28 @@ import graphene
 from crud import structurals_crud, contents_crud, projects_crud, nlp_crud
 from graphql_api import types, utils
 import schemas_nlp
+from routers import content_apis
+from authentication import get_current_user_data
 
 #Pylint error :- Query class have all resolver functions
 #pylint: disable=R0201
 #pylint: disable=too-many-arguments,too-many-public-methods
+# class Query(graphene.ObjectType):
+#     '''All defined queries'''
+#     languages = graphene.List(types.Language,
+#         description="Query languages in vachan-db",
+#         search_word=graphene.String(),
+#         language_name=graphene.String(), language_code=graphene.String(
+#             description="language code as per bcp47(usually 2 letter code)"),
+#         skip=graphene.Int(), limit=graphene.Int())
+#     def resolve_languages(self, info,
+#         search_word=None, language_code=None, language_name=None,
+#         skip=0, limit=100):
+#         '''resolver'''
+#         db_ = info.context["request"].db_session
+#         return structurals_crud.get_languages(db_, language_code=language_code,
+#             language_name=language_name, search_word=search_word,
+#             skip=skip, limit=limit)
 class Query(graphene.ObjectType):
     '''All defined queries'''
     languages = graphene.List(types.Language,
@@ -21,6 +39,17 @@ class Query(graphene.ObjectType):
         skip=0, limit=100):
         '''resolver'''
         db_ = info.context["request"].db_session
+
+        # req = info.context["request"]
+        # token = req.headers['Authorization']
+        # token = token.split(' ')[1]
+        # user_details = get_current_user_data(token)
+        # print("token===>",token)
+        # print("token===>",req.headers['Authorization'])
+        # print("user_details===>",user_details)
+        # return content_apis.get_language(req,language_code,language_name,
+        # search_word,skip,limit,user_details,db_)
+        
         return structurals_crud.get_languages(db_, language_code=language_code,
             language_name=language_name, search_word=search_word,
             skip=skip, limit=limit)

--- a/app/routers/content_apis.py
+++ b/app/routers/content_apis.py
@@ -224,7 +224,7 @@ async def edit_version(request: Request, ver_obj: schemas.VersionEdit = Body(...
         "data": structurals_crud.update_version(db_=db_, version=ver_obj,
         user_id=user_details['user_id'])}
 
-# ##### Source ##### 
+###### Source #####
 @router.get('/v2/sources',
     response_model=List[schemas.SourceResponse],
     responses={502: {"model": schemas.ErrorResponse},
@@ -251,7 +251,8 @@ async def get_source(request: Request,content_type: str=Query(None, example="com
     * returns [] for not available content'''
     log.info('In get_source')
     log.debug('contentType:%s, versionAbbreviation: %s, revision: %s, languageCode: %s,\
-        license_code:%s, metadata: %s, latest_revision: %s, active: %s, skip: %s, limit: %s',
+        license_code:%s, metadata: %s, access_tag: %s, latest_revision: %s, active: %s,\
+             skip: %s, limit: %s',
         content_type, version_abbreviation, revision, language_code, license_code, metadata,
         access_tag, latest_revision, active, skip, limit)
     return structurals_crud.get_sources(db_, content_type, version_abbreviation, revision=revision,

--- a/app/routers/content_apis.py
+++ b/app/routers/content_apis.py
@@ -224,7 +224,7 @@ async def edit_version(request: Request, ver_obj: schemas.VersionEdit = Body(...
         "data": structurals_crud.update_version(db_=db_, version=ver_obj,
         user_id=user_details['user_id'])}
 
-# ##### Source #####
+# ##### Source ##### 
 @router.get('/v2/sources',
     response_model=List[schemas.SourceResponse],
     responses={502: {"model": schemas.ErrorResponse},
@@ -237,6 +237,8 @@ async def get_source(request: Request,content_type: str=Query(None, example="com
     license_code: schemas.LicenseCodePattern=Query(None,example="ISC"),
     metadata: schemas.MetaDataPattern=Query(None,
         example='{"otherName": "KJBC, King James Bible Commentaries"}'),
+    # access_tag:List[schemas.SourcePermisions]=Query(schemas.SourcePermisions.CONTENT),
+    access_tag:List[schemas.SourcePermisions]=Query(None),
     active: bool = True, latest_revision: bool = True,
     skip: int = Query(0, ge=0), limit: int = Query(100, ge=0),
     user_details =Depends(get_user_or_none),db_: Session = Depends(get_db)):
@@ -251,10 +253,10 @@ async def get_source(request: Request,content_type: str=Query(None, example="com
     log.debug('contentType:%s, versionAbbreviation: %s, revision: %s, languageCode: %s,\
         license_code:%s, metadata: %s, latest_revision: %s, active: %s, skip: %s, limit: %s',
         content_type, version_abbreviation, revision, language_code, license_code, metadata,
-        latest_revision, active, skip, limit)
+        access_tag, latest_revision, active, skip, limit)
     return structurals_crud.get_sources(db_, content_type, version_abbreviation, revision=revision,
         language_code=language_code, license_code=license_code, metadata=metadata,
-        latest_revision=latest_revision, active=active,skip=skip, limit=limit)
+        access_tag=access_tag,latest_revision=latest_revision, active=active,skip=skip, limit=limit)
 
 @router.post('/v2/sources', response_model=schemas.SourceCreateResponse,
     responses={502: {"model": schemas.ErrorResponse}, \

--- a/app/test/test_gql_languages.py
+++ b/app/test/test_gql_languages.py
@@ -21,6 +21,7 @@ def test_get_all_data():
     }
     """
     executed = gql_request(default_get_query)
+    # print(executed)
     assert isinstance(executed, Dict)
     assert len(executed["data"]["languages"])>0
     assert isinstance(executed["data"]["languages"], list)

--- a/app/test/test_gql_versions.py
+++ b/app/test/test_gql_versions.py
@@ -38,6 +38,7 @@ def check_post(query, variables):
     assert isinstance(executed, Dict)
     assert executed["data"]["addVersion"]["message"] == "Version created successfully"
     item =executed["data"]["addVersion"]["data"]
+    print("Created Version Data ============>",item)
     item["versionId"] = int(item["versionId"])
     assert_positive_get(item)
     assert item["versionAbbreviation"] == variables["object"]["versionAbbreviation"]
@@ -269,14 +270,43 @@ def test_get_after_adding_data():
     variables2["object"]["revision"] = 2
     check_post(GLOBAL_QUERY,variables2)
 
-    executed_get = gql_request(QUERY_GET)
+    #get added versions
+    query_get_version_added = """
+        query get_version($VAbb:String){
+        versions(versionAbbreviation:$VAbb){
+    versionId
+    versionAbbreviation
+    versionName
+    revision
+    metaData
+  }
+}
+    """ 
+    get_version_var = {
+    "VAbb": "AAA"
+    }
+
+    executed_get = gql_request(query_get_version_added,variables=get_version_var)
     assert isinstance(executed_get, Dict)
-    assert len(executed_get["data"]["versions"]) == 4
+    assert len(executed_get["data"]["versions"]) == 2
     items =executed_get["data"]["versions"]
     for item in items:
         if 'versionId' in item:
             item["versionId"] = int(item["versionId"])
             assert_positive_get(item)
+
+    get_version_var = {
+    "VAbb": "BBB"
+    }
+
+    executed_get = gql_request(query_get_version_added,variables=get_version_var)
+    assert isinstance(executed_get, Dict)
+    assert len(executed_get["data"]["versions"]) == 2
+    items =executed_get["data"]["versions"]
+    for item in items:
+        if 'versionId' in item:
+            item["versionId"] = int(item["versionId"])
+            assert_positive_get(item)        
 
     #get test after successfull creation
     # filter with abbr

--- a/app/test/test_sources.py
+++ b/app/test/test_sources.py
@@ -404,13 +404,7 @@ def test_created_user_can_only_edit():
         "sourceName": 'ml_TTT_2_commentary',
         "revision": 1
     }
-    # vachanAdmin_user_data = {
-    #         "user_email": "vachanadmintest@mail.test",
-    #         "password": "passwordtest@1"
-    #     }
-    # response = login(vachanAdmin_user_data)
-    # assert response.json()['message'] == "Login Succesfull"
-    # test_user_token = response.json()["token"]
+    
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['VachanAdmin']['token']
 
     response = client.put(UNIT_URL, headers=headers_auth, json=data_update)
@@ -454,7 +448,7 @@ def test_soft_delete():
 def test_get_empty():
     '''Test get before adding data to table. Usually done on freshly set up test DB.
     If the testing is done on a DB that already has some data, the response wont be empty.'''
-    response = client.get(UNIT_URL,)
+    response = client.get(UNIT_URL + '?version_abbreviation=TTT')
     if len(response.json()) == 0:
         assert_not_available_content(response)
 
@@ -505,11 +499,13 @@ def test_get_after_adding_data():
     headers = {"contentType": "application/json", "accept": "application/json"}
     # filter with contentType
     #without auth
-    response = client.get(UNIT_URL + "?content_type=commentary&latest_revision=false",headers=headers)
+    response = client.get(UNIT_URL + "?content_type=commentary&version_abbreviation=TTT"+
+        "&latest_revision=false",headers=headers)
     assert response.status_code == 403
     assert response.json()['error'] == 'Permision Denied'
     #with auth
-    response = client.get(UNIT_URL + "?content_type=commentary&latest_revision=false",headers=headers_auth)
+    response = client.get(UNIT_URL + "?content_type=commentary&version_abbreviation=TTT"+
+        "&latest_revision=false",headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) >= 3
     for item in response.json():
@@ -517,18 +513,19 @@ def test_get_after_adding_data():
 
     # filter with language
     #without auth
-    response = client.get(UNIT_URL + "?language_code=hi&latest_revision=false")
+    response = client.get(UNIT_URL + "?language_code=hi&&version_abbreviation=TTT&latest_revision=false")
     assert response.status_code == 403
     assert response.json()['error'] == 'Permision Denied'
     #with auth
-    response = client.get(UNIT_URL + "?language_code=hi&latest_revision=false",headers=headers_auth)
+    response = client.get(UNIT_URL + "?language_code=hi&&version_abbreviation=TTT"+
+        "&latest_revision=false",headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) >= 3
     for item in response.json():
         assert_positive_get(item)
 
     # filter with revision  #WITH AUTH
-    response = client.get(UNIT_URL + "?revision=2",headers=headers_auth)
+    response = client.get(UNIT_URL + "?revision=2&version_abbreviation=TTT",headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) >= 3
     for item in response.json():
@@ -542,20 +539,21 @@ def test_get_after_adding_data():
         assert_positive_get(item)
 
     # filter with license
-    response = client.get(UNIT_URL + "?license=CC-BY-SA",headers=headers_auth)
+    response = client.get(UNIT_URL + "?license=CC-BY-SA&version_abbreviation=TTT",headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) >= 6
     for item in response.json():
         assert_positive_get(item)
 
-    response = client.get(UNIT_URL + "?license=ISC",headers=headers_auth)
+    response = client.get(UNIT_URL + "?license=ISC&version_abbreviation=TTT",headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) >= 3
     for item in response.json():
         assert_positive_get(item)
 
     # filter with metadata
-    response = client.get(UNIT_URL + '?metadata={"owner": "myself"}&latest_revision=false',headers=headers_auth)
+    response = client.get(UNIT_URL + '?metadata={"owner": "myself"}&&version_abbreviation=TTT'+
+        '&latest_revision=false',headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 3
     for item in response.json():
@@ -598,25 +596,25 @@ def test_get_source_filter_access_tag():
     for item in response1.json():
         assert_positive_get(item)
 
-    response2 = client.get(UNIT_URL + '?access_tag=open-access',headers=headers_auth)
+    response2 = client.get(UNIT_URL + '?version_abbreviation=TTT&access_tag=open-access',headers=headers_auth)
     assert response2.status_code == 200
     assert len(response2.json()) == 1
     for item in response2.json():
         assert_positive_get(item)
 
-    response3 = client.get(UNIT_URL + '?access_tag=publishable',headers=headers_auth)
+    response3 = client.get(UNIT_URL + '?version_abbreviation=TTT&access_tag=publishable',headers=headers_auth)
     assert response3.status_code == 200
     assert len(response3.json()) == 1
     for item in response3.json():
         assert_positive_get(item)
 
-    response4 = client.get(UNIT_URL + '?access_tag=content',headers=headers_auth)
+    response4 = client.get(UNIT_URL + '?version_abbreviation=TTT&access_tag=content',headers=headers_auth)
     assert response4.status_code == 200
     assert len(response4.json()) == 3
     for item in response4.json():
         assert_positive_get(item)
 
-    response5 = client.get(UNIT_URL + '?access_tag=publishable&access_tag=open-access',headers=headers_auth)
+    response5 = client.get(UNIT_URL + '?version_abbreviation=TTT&access_tag=publishable&access_tag=open-access',headers=headers_auth)
     assert response5.status_code == 200
     assert len(response5.json()) == 0
 
@@ -625,7 +623,7 @@ def test_get_source_filter_access_tag():
     data['accessPermissions'] = ['publishable','open-access']
     check_post(data)
 
-    response6 = client.get(UNIT_URL + '?access_tag=publishable&access_tag=open-access',headers=headers_auth)
+    response6 = client.get(UNIT_URL + '?version_abbreviation=TTT&access_tag=publishable&access_tag=open-access',headers=headers_auth)
     assert response6.status_code == 200
     assert len(response6.json()) == 1
     
@@ -696,26 +694,26 @@ def test_diffrernt_sources_with_app_and_roles():
 
     #Get without Login
     #default : API
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 1
     resp_data = response.json()[0]['metaData']
     assert 'open-access' in resp_data['accessPermissions']
     #APP : Autographa
     headers_auth['app'] = AG
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 403
     assert response.json()['error'] == 'Permision Denied'
     #APP : Vachan Online
     headers_auth['app'] = VACHAN
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 2
     assert 'publishable' in response.json()[1]['metaData']['accessPermissions']
     assert 'open-access' in response.json()[0]['metaData']['accessPermissions']
     #APP : Vachan Admin
     headers_auth['app'] = VACHANADMIN
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 403
     assert response.json()['error'] == 'Permision Denied'
 
@@ -723,28 +721,28 @@ def test_diffrernt_sources_with_app_and_roles():
     #default : API
     headers_auth = {"contentType": "application/json","accept": "application/json"}
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 2
     assert 'open-access' in response.json()[0]['metaData']['accessPermissions']
     assert 'publishable' in response.json()[1]['metaData']['accessPermissions']
     #APP : Autographa
     headers_auth['app'] = AG
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 2
     assert 'open-access' in response.json()[0]['metaData']['accessPermissions']
     assert 'publishable' in response.json()[1]['metaData']['accessPermissions']
     #APP : Vachan Online
     headers_auth['app'] = VACHAN
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 2
     assert 'open-access' in response.json()[0]['metaData']['accessPermissions']
     assert 'publishable' in response.json()[1]['metaData']['accessPermissions']
     #APP : Vachan Admin
     headers_auth['app'] = VACHANADMIN
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 403
     assert response.json()['error'] == 'Permision Denied'
 
@@ -752,26 +750,26 @@ def test_diffrernt_sources_with_app_and_roles():
     #default : API
     headers_auth = {"contentType": "application/json","accept": "application/json"}
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['VachanUser']['token']
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 2
     assert 'open-access' in response.json()[0]['metaData']['accessPermissions']
     assert 'publishable' in response.json()[1]['metaData']['accessPermissions']
     #APP : Autographa
     headers_auth['app'] = AG
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 403
     assert response.json()['error'] == 'Permision Denied'
     #APP : Vachan Online
     headers_auth['app'] = VACHAN
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 2
     assert 'open-access' in response.json()[0]['metaData']['accessPermissions']
     assert 'publishable' in response.json()[1]['metaData']['accessPermissions']
     #APP : Vachan Admin
     headers_auth['app'] = VACHANADMIN
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 403
     assert response.json()['error'] == 'Permision Denied'
 
@@ -779,7 +777,7 @@ def test_diffrernt_sources_with_app_and_roles():
     #default : API
     headers_auth = {"contentType": "application/json","accept": "application/json"}
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['VachanAdmin']['token']
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 5
     assert 'content' in response.json()[0]['metaData']['accessPermissions']
@@ -789,19 +787,19 @@ def test_diffrernt_sources_with_app_and_roles():
     assert 'derivable' in response.json()[4]['metaData']['accessPermissions']
     #APP : Autographa
     headers_auth['app'] = AG
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 403
     assert response.json()['error'] == 'Permision Denied'
     #APP : Vachan Online
     headers_auth['app'] = VACHAN
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 2
     assert 'open-access' in response.json()[0]['metaData']['accessPermissions']
     assert 'publishable' in response.json()[1]['metaData']['accessPermissions']
     #APP : Vachan Admin
     headers_auth['app'] = VACHANADMIN
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert len(response.json()) == 5
     assert 'content' in response.json()[0]['metaData']['accessPermissions']
     assert 'open-access' in response.json()[1]['metaData']['accessPermissions']
@@ -813,26 +811,26 @@ def test_diffrernt_sources_with_app_and_roles():
     #default : API
     headers_auth = {"contentType": "application/json","accept": "application/json"}
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['APIUser']['token']
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 2
     assert 'open-access' in response.json()[0]['metaData']['accessPermissions']
     assert 'publishable' in response.json()[1]['metaData']['accessPermissions']
     #APP : Autographa
     headers_auth['app'] = AG
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 403
     assert response.json()['error'] == 'Permision Denied'
     #APP : Vachan Online
     headers_auth['app'] = VACHAN
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 2
     assert 'open-access' in response.json()[0]['metaData']['accessPermissions']
     assert 'publishable' in response.json()[1]['metaData']['accessPermissions']
     #APP : Vachan Admin
     headers_auth['app'] = VACHANADMIN
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 403
     assert response.json()['error'] == 'Permision Denied'
 
@@ -840,28 +838,28 @@ def test_diffrernt_sources_with_app_and_roles():
     #default : API
     headers_auth = {"contentType": "application/json","accept": "application/json"}
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 2
     assert 'open-access' in response.json()[0]['metaData']['accessPermissions']
     assert 'publishable' in response.json()[1]['metaData']['accessPermissions']
     #APP : Autographa
     headers_auth['app'] = AG
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 2
     assert 'open-access' in response.json()[0]['metaData']['accessPermissions']
     assert 'publishable' in response.json()[1]['metaData']['accessPermissions']
     #APP : Vachan Online
     headers_auth['app'] = VACHAN
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 2
     assert 'open-access' in response.json()[0]['metaData']['accessPermissions']
     assert 'publishable' in response.json()[1]['metaData']['accessPermissions']
     #APP : Vachan Admin
     headers_auth['app'] = VACHANADMIN
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 403
     assert response.json()['error'] == 'Permision Denied'
 
@@ -869,7 +867,7 @@ def test_diffrernt_sources_with_app_and_roles():
     #default : API
     headers_auth = {"contentType": "application/json","accept": "application/json"}
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['BcsDev']['token']
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 5
     assert 'content' in response.json()[0]['metaData']['accessPermissions']
@@ -879,19 +877,19 @@ def test_diffrernt_sources_with_app_and_roles():
     assert 'derivable' in response.json()[4]['metaData']['accessPermissions']
     #APP : Autographa
     headers_auth['app'] = AG
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 403
     assert response.json()['error'] == 'Permision Denied'
     #APP : Vachan Online
     headers_auth['app'] = VACHAN
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 2
     assert 'open-access' in response.json()[0]['metaData']['accessPermissions']
     assert 'publishable' in response.json()[1]['metaData']['accessPermissions']
     #APP : Vachan Admin
     headers_auth['app'] = VACHANADMIN
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 403
     assert response.json()['error'] == 'Permision Denied'
 
@@ -908,7 +906,7 @@ def test_diffrernt_sources_with_app_and_roles():
     #default : API
     headers_auth = {"contentType": "application/json","accept": "application/json"}
     headers_auth['Authorization'] = "Bearer"+" "+ test_user_token
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 5
     assert 'content' in response.json()[0]['metaData']['accessPermissions']
@@ -918,21 +916,21 @@ def test_diffrernt_sources_with_app_and_roles():
     assert 'derivable' in response.json()[4]['metaData']['accessPermissions']
     #APP : Autographa
     headers_auth['app'] = AG
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 2
     assert 'open-access' in response.json()[0]['metaData']['accessPermissions']
     assert 'publishable' in response.json()[1]['metaData']['accessPermissions']
     #APP : Vachan Online
     headers_auth['app'] = VACHAN
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 2
     assert 'open-access' in response.json()[0]['metaData']['accessPermissions']
     assert 'publishable' in response.json()[1]['metaData']['accessPermissions']
     #APP : Vachan Admin
     headers_auth['app'] = VACHANADMIN
-    response = client.get(UNIT_URL, headers=headers_auth)
+    response = client.get(UNIT_URL+ '?version_abbreviation=TTT', headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 5
     assert 'content' in response.json()[0]['metaData']['accessPermissions']

--- a/app/test/test_sources.py
+++ b/app/test/test_sources.py
@@ -597,26 +597,40 @@ def test_get_source_filter_access_tag():
     assert len(response1.json()) == 3
     for item in response1.json():
         assert_positive_get(item)
+
     response2 = client.get(UNIT_URL + '?access_tag=open-access',headers=headers_auth)
     assert response2.status_code == 200
     assert len(response2.json()) == 1
     for item in response2.json():
         assert_positive_get(item)
+
     response3 = client.get(UNIT_URL + '?access_tag=publishable',headers=headers_auth)
     assert response3.status_code == 200
     assert len(response3.json()) == 1
     for item in response3.json():
         assert_positive_get(item)
+
     response4 = client.get(UNIT_URL + '?access_tag=content',headers=headers_auth)
     assert response4.status_code == 200
     assert len(response4.json()) == 3
     for item in response4.json():
         assert_positive_get(item)
-    response4 = client.get(UNIT_URL + '?access_tag=publishable&access_tag=open-access',headers=headers_auth)
-    assert response4.status_code == 200
-    assert len(response4.json()) == 2
-    for item in response4.json():
-        assert_positive_get(item)        
+
+    # response5 = client.get(UNIT_URL + '?access_tag=publishable&access_tag=open-access',headers=headers_auth)
+    # print("resposne===4 both ===>",response5.json())
+    # assert response5.status_code == 200
+    # assert len(response5.json()) == 0
+
+    #Add source with access tags publishable , open-access
+    data['language'] = 'ho'
+    data['accessPermissions'] = ['publishable','open-access']
+    check_post(data)
+
+    response6 = client.get(UNIT_URL + '?access_tag=publishable&access_tag=open-access',headers=headers_auth)
+    print("resposne===5 both ===>",response6.json())
+    assert response6.status_code == 200
+    assert len(response6.json()) == 1
+    
         
 
 def test_diffrernt_sources_with_app_and_roles():

--- a/app/test/test_sources.py
+++ b/app/test/test_sources.py
@@ -570,7 +570,6 @@ def test_get_after_adding_data():
 
 def test_get_source_filter_access_tag():
     """filter source with access tags"""
-    #########################################################################################################
     version_data = {
         "versionAbbreviation": "TTT",
         "versionName": "test version",

--- a/app/test/test_sources.py
+++ b/app/test/test_sources.py
@@ -616,10 +616,9 @@ def test_get_source_filter_access_tag():
     for item in response4.json():
         assert_positive_get(item)
 
-    # response5 = client.get(UNIT_URL + '?access_tag=publishable&access_tag=open-access',headers=headers_auth)
-    # print("resposne===4 both ===>",response5.json())
-    # assert response5.status_code == 200
-    # assert len(response5.json()) == 0
+    response5 = client.get(UNIT_URL + '?access_tag=publishable&access_tag=open-access',headers=headers_auth)
+    assert response5.status_code == 200
+    assert len(response5.json()) == 0
 
     #Add source with access tags publishable , open-access
     data['language'] = 'ho'
@@ -627,7 +626,6 @@ def test_get_source_filter_access_tag():
     check_post(data)
 
     response6 = client.get(UNIT_URL + '?access_tag=publishable&access_tag=open-access',headers=headers_auth)
-    print("resposne===5 both ===>",response6.json())
     assert response6.status_code == 200
     assert len(response6.json()) == 1
     


### PR DESCRIPTION
#260 
In GET /v2/sources, add an optional query param to filter contents based on access tag given for them.
PR contains the filter option for get source based on the provided access tags.

In PUT /v2/sources, add provision to update(add/remove) access tags for a particular source table
     This is already covered in the previous PR for sources. PUT for v2/sources have an option to update the access tags for the source table 
