### PR TITLE
Feature/get text api

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -40,4 +40,4 @@ jobs:
         run: |
           pip install -r requirements.txt
           cd app 
-          python -m pytest --disable-warnings -k "not agmt and not translation and not bibles and not auth"
+          python -m pytest --disable-warnings -k "not agmt and not translation and not bibles and not auth and not source_get_sentence"

--- a/app/crud/contents_crud.py
+++ b/app/crud/contents_crud.py
@@ -705,23 +705,25 @@ def extract_text(db_:Session, tables, books):
     The text column would be determined based on the table type'''
     sentence_list = []
     for table in tables:
+        print(table.sourceName)
         if table.contentType.contentType == db_models.ContentTypeName.BIBLE.value:
             model_cls = db_models.dynamicTables[table.sourceName+'_cleaned']
             query = db_.query(model_cls.refId.label('sentenceId'),
                 model_cls.refString.label('surrogateId'),
-                model_cls.verseText.label('sentence'))
+                model_cls.verseText.label('sentence')).join(model_cls.book)
         elif table.contentType.contentType == db_models.ContentTypeName.COMMENTARY.value:
             model_cls = db_models.dynamicTables[table.sourceName]
             query = db_.query(model_cls.commentaryId.label('sentenceId'),
                 model_cls.refString.label('surrogateId'),
-                model_cls.commentary.label('sentence'))
+                model_cls.commentary.label('sentence')).join(model_cls.book)
         else:
             continue
         if books is not None:
-            query = query.join(model_cls.book).filter(
+            query = query.filter(
                 db_models.BibleBook.bookCode.in_([buk.lower() for buk in books]))
+            print(query)
             # query = query.filter(model_cls.book.bookCode.in_([buk.lower() for buk in books]))
-        sentence_list = query.all()
+        sentence_list += query.all()
     if len(sentence_list)==0:
         raise NotAvailableException("Not text available for the specified source or language")
     return sentence_list

--- a/app/crud/contents_crud.py
+++ b/app/crud/contents_crud.py
@@ -721,6 +721,7 @@ def extract_text(db_:Session, tables, books, skip=0, limit=100):
             query = query.filter(
                 db_models.BibleBook.bookCode.in_([buk.lower() for buk in books]))
         sentence_list += query.offset(skip).limit(limit).all()
-    if len(sentence_list)==0:
-        raise NotAvailableException("Not text available for the specified source or language")
+        if len(sentence_list) >= limit:
+            sentence_list = sentence_list[:limit]
+            break
     return sentence_list

--- a/app/crud/contents_crud.py
+++ b/app/crud/contents_crud.py
@@ -700,7 +700,7 @@ def get_bible_verses(db_:Session, source_name, book_code=None, chapter=None, ver
         ref_combined_results.append(ref_combined)
     return ref_combined_results
 
-def extract_text(db_:Session, tables, books):
+def extract_text(db_:Session, tables, books, skip=0, limit=100):
     '''get all text field contents from the list of tables provided.
     The text column would be determined based on the table type'''
     sentence_list = []
@@ -720,7 +720,7 @@ def extract_text(db_:Session, tables, books):
         if books is not None:
             query = query.filter(
                 db_models.BibleBook.bookCode.in_([buk.lower() for buk in books]))
-        sentence_list += query.all()
+        sentence_list += query.offset(skip).limit(limit).all()
     if len(sentence_list)==0:
         raise NotAvailableException("Not text available for the specified source or language")
     return sentence_list

--- a/app/crud/contents_crud.py
+++ b/app/crud/contents_crud.py
@@ -700,7 +700,7 @@ def get_bible_verses(db_:Session, source_name, book_code=None, chapter=None, ver
         ref_combined_results.append(ref_combined)
     return ref_combined_results
 
-def extract_text(db_:Session, tables):
+def extract_text(db_:Session, tables, books):
     '''get all text field contents from the list of tables provided.
     The text column would be determined based on the table type'''
     sentence_list = []
@@ -715,7 +715,11 @@ def extract_text(db_:Session, tables):
                 model_cls.commentary.label('sentence'))
         else:
             continue
-        sentence_list += query.all()
+        if books is not None:
+            query = query.join(model_cls.book).filter(
+                db_models.BibleBook.bookCode.in_([buk.lower() for buk in books]))
+            # query = query.filter(model_cls.book.bookCode.in_([buk.lower() for buk in books]))
+        sentence_list = query.all()
     if len(sentence_list)==0:
         raise NotAvailableException("Not text available for the specified source or language")
     return sentence_list

--- a/app/crud/contents_crud.py
+++ b/app/crud/contents_crud.py
@@ -709,12 +709,12 @@ def extract_text(db_:Session, tables, books):
         if table.contentType.contentType == db_models.ContentTypeName.BIBLE.value:
             model_cls = db_models.dynamicTables[table.sourceName+'_cleaned']
             query = db_.query(model_cls.refId.label('sentenceId'),
-                model_cls.refString.label('surrogateId'),
+                model_cls.ref_string.label('surrogateId'),
                 model_cls.verseText.label('sentence')).join(model_cls.book)
         elif table.contentType.contentType == db_models.ContentTypeName.COMMENTARY.value:
             model_cls = db_models.dynamicTables[table.sourceName]
             query = db_.query(model_cls.commentaryId.label('sentenceId'),
-                model_cls.refString.label('surrogateId'),
+                model_cls.ref_string.label('surrogateId'),
                 model_cls.commentary.label('sentence')).join(model_cls.book)
         else:
             continue

--- a/app/crud/contents_crud.py
+++ b/app/crud/contents_crud.py
@@ -708,10 +708,12 @@ def extract_text(db_:Session, tables, books):
         if table.contentType.contentType == db_models.ContentTypeName.BIBLE.value:
             model_cls = db_models.dynamicTables[table.sourceName+'_cleaned']
             query = db_.query(model_cls.refId.label('sentenceId'),
+                model_cls.refString.label('surrogateId'),
                 model_cls.verseText.label('sentence'))
         elif table.contentType.contentType == db_models.ContentTypeName.COMMENTARY.value:
             model_cls = db_models.dynamicTables[table.sourceName]
             query = db_.query(model_cls.commentaryId.label('sentenceId'),
+                model_cls.refString.label('surrogateId'),
                 model_cls.commentary.label('sentence'))
         else:
             continue

--- a/app/crud/contents_crud.py
+++ b/app/crud/contents_crud.py
@@ -705,7 +705,6 @@ def extract_text(db_:Session, tables, books):
     The text column would be determined based on the table type'''
     sentence_list = []
     for table in tables:
-        print(table.sourceName)
         if table.contentType.contentType == db_models.ContentTypeName.BIBLE.value:
             model_cls = db_models.dynamicTables[table.sourceName+'_cleaned']
             query = db_.query(model_cls.refId.label('sentenceId'),
@@ -721,8 +720,6 @@ def extract_text(db_:Session, tables, books):
         if books is not None:
             query = query.filter(
                 db_models.BibleBook.bookCode.in_([buk.lower() for buk in books]))
-            print(query)
-            # query = query.filter(model_cls.book.bookCode.in_([buk.lower() for buk in books]))
         sentence_list += query.all()
     if len(sentence_list)==0:
         raise NotAvailableException("Not text available for the specified source or language")

--- a/app/crud/utils.py
+++ b/app/crud/utils.py
@@ -166,3 +166,12 @@ def validate_language_tag(tag):
     if resp.status_code != 200:
         resp.raise_for_status()
     return resp.json()[0]['Valid'], ' '.join(resp.json()[0]['Messages'])
+
+
+def convert_dict_obj_to_pydantic(input_obj, target_class):
+    '''convert a graphene input object into specified pydantic model'''
+    kwargs = {}
+    for key in input_obj:
+        kwargs[key] = input_obj[key]
+    new_obj = target_class(**kwargs)
+    return new_obj

--- a/app/db_models.py
+++ b/app/db_models.py
@@ -5,14 +5,13 @@ from sqlalchemy import Column, Integer, String, JSON, ARRAY
 from sqlalchemy import Boolean, ForeignKey, DateTime
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.sql import func
-from sqlalchemy.orm import relationship, Session, column_property
+from sqlalchemy.orm import relationship, Session
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.schema import Sequence
 from sqlalchemy.ext.hybrid import hybrid_property
 
 from database import Base
 from custom_exceptions import GenericException
-from crud.utils import books
 
 class ContentTypeName(Enum):
     '''The string literals used as value of ContentType field in ContentType
@@ -117,11 +116,11 @@ class Commentary(): # pylint: disable=too-few-public-methods
         '''For modelling the book field in derived classes'''
         return relationship(BibleBook)
     @hybrid_property
-    def refString(self): # pylint: disable=E0213
+    def ref_string(self):
         '''To compose surrogate id'''
         return f'{self.book.bookCode} {self.chapter}:{self.verseStart}-{self.verseEnd}'
-    @refString.expression
-    def refString(cls):
+    @ref_string.expression
+    def ref_string(cls): # pylint: disable=E0213
         '''To compose surrogate id'''
         return func.concat(BibleBook.bookCode," ",cls.chapter,":",cls.verseStart,"-",cls.verseEnd)
     chapter = Column('chapter', Integer)
@@ -231,12 +230,12 @@ class BibleContentCleaned(): # pylint: disable=too-few-public-methods
         '''For modelling the book field in bible content classes'''
         return relationship(BibleBook)
     @hybrid_property
-    def refString(self): # pylint: disable=E0213
+    def ref_string(self):
         '''To compose surrogate id'''
         return f'{self.book.bookCode} {self.chapter}:{self.verseNumber}'
 
-    @refString.expression
-    def refString(cls):
+    @ref_string.expression
+    def ref_string(cls): # pylint: disable=E0213
         '''To compose surrogate id'''
         return func.concat(BibleBook.bookCode," ",cls.chapter,":",cls.verseNumber)
     chapter = Column('chapter', Integer)

--- a/app/graphql_api/mutations.py
+++ b/app/graphql_api/mutations.py
@@ -1,6 +1,5 @@
 '''GraphQL queries and mutations'''
 import graphene
-from starlette.datastructures import URL
 import schemas
 import schemas_nlp
 from routers import translation_apis

--- a/app/graphql_api/mutations.py
+++ b/app/graphql_api/mutations.py
@@ -1,7 +1,9 @@
 '''GraphQL queries and mutations'''
 import graphene
+from starlette.datastructures import URL
 import schemas
 import schemas_nlp
+from routers import translation_apis
 from crud import structurals_crud,contents_crud,projects_crud,nlp_crud
 from graphql_api import types, utils
 #Data classes and graphql classes have few methods
@@ -500,21 +502,18 @@ class EditAGMTProject(graphene.Mutation):
     def mutate(self,info,project_arg):
         """resolve"""
         db_ = info.context["request"].db_session
+        req = info.context['request']
+        req.scope['method'] = "PUT"
+        req.scope['path'] = "/v2/autographa/projects"
         schema_model = utils.convert_graphene_obj_to_pydantic\
             (project_arg,schemas_nlp.TranslationProjectEdit)
 
-        result = projects_crud.update_agmt_project(db_=db_,project_obj=schema_model,user_id=10101)
-        comm = types.TranslationProject(
-            projectId = result.projectId,
-            projectName = result.projectName,
-            sourceLanguage = result.sourceLanguage,
-            targetLanguage = result.targetLanguage,
-            documentFormat = result.documentFormat,
-            users = result.users,
-            metaData = result.metaData,
-            active = result.active
-        )
-        message = "Project updated successfully"
+        result = translation_apis.update_project(
+            request=req,
+            project_obj=schema_model,
+            db_=db_)
+        message = result["message"]
+        comm = result["data"]
         return EditAGMTProject(message = message, data = comm)
 
 ##### AGMT project user #######

--- a/app/graphql_api/types.py
+++ b/app/graphql_api/types.py
@@ -481,7 +481,7 @@ class InputEditAGMTProject(graphene.InputObjectType):
     projectName = graphene.String(\
         description="example: Hindi Malayalam Gospels")
     selectedBooks = graphene.Field(InputSeclectedBooks)
-    uploadedBooks = graphene.List(graphene.String)
+    uploadedUSFMs = graphene.List(graphene.String)
     useDataForLearning = graphene.Boolean()
     stopwords = graphene.Field(Stopwords)
     punctuations = graphene.List(graphene.String,\

--- a/app/routers/content_apis.py
+++ b/app/routers/content_apis.py
@@ -3,7 +3,7 @@ from typing import List
 from fastapi import APIRouter, Query, Body, Depends, Path
 from sqlalchemy.orm import Session
 
-import schemas
+import schemas, schemas_nlp
 from dependencies import get_db, log
 from custom_exceptions import NotAvailableException, AlreadyExistsException
 from crud import structurals_crud, contents_crud
@@ -658,3 +658,27 @@ def edit_biblevideo(source_name:schemas.TableNamePattern=Path(...,example="en_TB
     return {'message': "Bible videos updated successfully",
         "data": contents_crud.update_bible_videos(db_=db_, source_name=source_name,
         videos=videos, user_id=None)}
+
+@router.get('/v2/sources/get-sentence', response_model=List[schemas_nlp.SentenceInput],
+    responses={502: {"model": schemas.ErrorResponse},
+    422: {"model": schemas.ErrorResponse}}, status_code=200, tags=["Sources"])
+def extract_text_contents(source_name:schemas.TableNamePattern=Query(None,example="en_TBP_1_bible"),
+    language_code=Query(None, example="hi"),
+    db_: Session = Depends(get_db)):
+    '''A generic API for all content type tables to get just the text contents of that table
+    that could be used for translation, as corpus for NLP operations like SW identification'''
+    log.info('In extract_text_contents')
+    log.debug('source_name: %s, language_code: %s',source_name, language_code)
+    tables = structurals_crud.get_sources(db_, source_name=source_name, language_code=language_code)
+    # the projects sources or drafts where people are willing to share their data for learning 
+    # could be used for text content extraction. But need to be able to filter projects based on 
+    # use_data_for_learning flag and translation status(need to add a field in metadata for that).
+    # projects = projects_crud.get_agmt_projects(db_, source_language=language_code) +
+    #     projects_crud.get_agmt_projects(db_, target_language=language_code)
+    if len(tables) == 0:
+        raise NotAvailableException("No sources available for the requested name or language")
+    return contents_crud.extract_text(db_, tables)
+
+
+
+

--- a/app/routers/content_apis.py
+++ b/app/routers/content_apis.py
@@ -663,6 +663,7 @@ def edit_biblevideo(source_name:schemas.TableNamePattern=Path(...,example="en_TB
     responses={502: {"model": schemas.ErrorResponse},
     422: {"model": schemas.ErrorResponse}}, status_code=200, tags=["Sources"])
 def extract_text_contents(source_name:schemas.TableNamePattern=Query(None,example="en_TBP_1_bible"),
+    books:List[schemas.BookCodePattern]=Query(None,example='GEN'),
     language_code=Query(None, example="hi"),
     db_: Session = Depends(get_db)):
     '''A generic API for all content type tables to get just the text contents of that table
@@ -677,7 +678,7 @@ def extract_text_contents(source_name:schemas.TableNamePattern=Query(None,exampl
     #     projects_crud.get_agmt_projects(db_, target_language=language_code)
     if len(tables) == 0:
         raise NotAvailableException("No sources available for the requested name or language")
-    return contents_crud.extract_text(db_, tables)
+    return contents_crud.extract_text(db_, tables, books)
 
 
 

--- a/app/routers/content_apis.py
+++ b/app/routers/content_apis.py
@@ -666,13 +666,15 @@ def edit_biblevideo(source_name:schemas.TableNamePattern=Path(...,example="en_TB
 def extract_text_contents(request:Request, #pylint: disable=W0613
     source_name:schemas.TableNamePattern=Query(None,example="en_TBP_1_bible"),
     books:List[schemas.BookCodePattern]=Query(None,example='GEN'),
-    language_code=Query(None, example="hi"),
+    language_code:schemas.LangCodePattern=Query(None, example="hi"),
+    content_type:str=Query(None, example="commentary"),
     db_: Session = Depends(get_db)):
     '''A generic API for all content type tables to get just the text contents of that table
     that could be used for translation, as corpus for NLP operations like SW identification'''
     log.info('In extract_text_contents')
     log.debug('source_name: %s, language_code: %s',source_name, language_code)
-    tables = structurals_crud.get_sources(db_, source_name=source_name, language_code=language_code)
+    tables = structurals_crud.get_sources(db_, source_name=source_name, language_code=language_code,
+        content_type=content_type)
     # the projects sources or drafts where people are willing to share their data for learning
     # could be used for text content extraction. But need to be able to filter projects based on
     # use_data_for_learning flag and translation status(need to add a field in metadata for that).

--- a/app/routers/content_apis.py
+++ b/app/routers/content_apis.py
@@ -3,7 +3,8 @@ from typing import List
 from fastapi import APIRouter, Query, Body, Depends, Path, Request
 from sqlalchemy.orm import Session
 
-import schemas, schemas_nlp
+import schemas
+import schemas_nlp
 from dependencies import get_db, log
 from custom_exceptions import NotAvailableException, AlreadyExistsException
 from crud import structurals_crud, contents_crud
@@ -662,7 +663,8 @@ def edit_biblevideo(source_name:schemas.TableNamePattern=Path(...,example="en_TB
 @router.get('/v2/sources/get-sentence', response_model=List[schemas_nlp.SentenceInput],
     responses={502: {"model": schemas.ErrorResponse},
     422: {"model": schemas.ErrorResponse}}, status_code=200, tags=["Sources"])
-def extract_text_contents(request:Request, source_name:schemas.TableNamePattern=Query(None,example="en_TBP_1_bible"),
+def extract_text_contents(request:Request, #pylint: disable=W0613
+    source_name:schemas.TableNamePattern=Query(None,example="en_TBP_1_bible"),
     books:List[schemas.BookCodePattern]=Query(None,example='GEN'),
     language_code=Query(None, example="hi"),
     db_: Session = Depends(get_db)):
@@ -671,15 +673,11 @@ def extract_text_contents(request:Request, source_name:schemas.TableNamePattern=
     log.info('In extract_text_contents')
     log.debug('source_name: %s, language_code: %s',source_name, language_code)
     tables = structurals_crud.get_sources(db_, source_name=source_name, language_code=language_code)
-    # the projects sources or drafts where people are willing to share their data for learning 
-    # could be used for text content extraction. But need to be able to filter projects based on 
+    # the projects sources or drafts where people are willing to share their data for learning
+    # could be used for text content extraction. But need to be able to filter projects based on
     # use_data_for_learning flag and translation status(need to add a field in metadata for that).
     # projects = projects_crud.get_agmt_projects(db_, source_language=language_code) +
     #     projects_crud.get_agmt_projects(db_, target_language=language_code)
     if len(tables) == 0:
         raise NotAvailableException("No sources available for the requested name or language")
     return contents_crud.extract_text(db_, tables, books)
-
-
-
-

--- a/app/routers/content_apis.py
+++ b/app/routers/content_apis.py
@@ -1,6 +1,6 @@
 '''API endpoints related to content management'''
 from typing import List
-from fastapi import APIRouter, Query, Body, Depends, Path
+from fastapi import APIRouter, Query, Body, Depends, Path, Request
 from sqlalchemy.orm import Session
 
 import schemas, schemas_nlp
@@ -662,7 +662,7 @@ def edit_biblevideo(source_name:schemas.TableNamePattern=Path(...,example="en_TB
 @router.get('/v2/sources/get-sentence', response_model=List[schemas_nlp.SentenceInput],
     responses={502: {"model": schemas.ErrorResponse},
     422: {"model": schemas.ErrorResponse}}, status_code=200, tags=["Sources"])
-def extract_text_contents(source_name:schemas.TableNamePattern=Query(None,example="en_TBP_1_bible"),
+def extract_text_contents(request:Request, source_name:schemas.TableNamePattern=Query(None,example="en_TBP_1_bible"),
     books:List[schemas.BookCodePattern]=Query(None,example='GEN'),
     language_code=Query(None, example="hi"),
     db_: Session = Depends(get_db)):

--- a/app/routers/content_apis.py
+++ b/app/routers/content_apis.py
@@ -204,7 +204,7 @@ def edit_version(ver_obj: schemas.VersionEdit = Body(...), db_: Session = Depend
     response_model=List[schemas.SourceResponse],
     responses={502: {"model": schemas.ErrorResponse},
     422: {"model": schemas.ErrorResponse}}, status_code=200, tags=["Sources"])
-def get_source(request:Request, content_type: str=Query(None, example="commentary"),
+def get_source(request:Request, content_type: str=Query(None, example="commentary"), #pylint: disable=W0613
     version_abbreviation: schemas.VersionPattern=Query(None,example="KJV"),
     revision: int=Query(None, example=1),
     language_code: schemas.LangCodePattern=Query(None,example="en"),
@@ -672,7 +672,7 @@ def extract_text_contents(request:Request, #pylint: disable=W0613
     db_: Session = Depends(get_db)):
     '''A generic API for all content type tables to get just the text contents of that table
     that could be used for translation, as corpus for NLP operations like SW identification.
-    If source_name is provided, only that filter will be considered over content_type and language.'''
+    If source_name is provided, only that filter will be considered over content_type & language.'''
     log.info('In extract_text_contents')
     log.debug('source_name: %s, language_code: %s',source_name, language_code)
     version_abbreviation = None

--- a/app/routers/content_apis.py
+++ b/app/routers/content_apis.py
@@ -668,6 +668,7 @@ def extract_text_contents(request:Request, #pylint: disable=W0613
     books:List[schemas.BookCodePattern]=Query(None,example='GEN'),
     language_code:schemas.LangCodePattern=Query(None, example="hi"),
     content_type:str=Query(None, example="commentary"),
+    skip: int = Query(0, ge=0), limit: int = Query(100, ge=0),
     db_: Session = Depends(get_db)):
     '''A generic API for all content type tables to get just the text contents of that table
     that could be used for translation, as corpus for NLP operations like SW identification'''
@@ -682,4 +683,4 @@ def extract_text_contents(request:Request, #pylint: disable=W0613
     #     projects_crud.get_agmt_projects(db_, target_language=language_code)
     if len(tables) == 0:
         raise NotAvailableException("No sources available for the requested name or language")
-    return contents_crud.extract_text(db_, tables, books)
+    return contents_crud.extract_text(db_, tables, books, skip=skip, limit=limit)

--- a/app/routers/translation_apis.py
+++ b/app/routers/translation_apis.py
@@ -57,6 +57,7 @@ def update_project(request: Request, project_obj:schemas_nlp.TranslationProjectE
             books=project_obj.selectedBooks.books,
             language_code=None,
             content_type='bible',
+            skip=0, limit=100000,
             db_=db_)
         if "error" in response:
             raise GenericException(response['error'])

--- a/app/routers/translation_apis.py
+++ b/app/routers/translation_apis.py
@@ -1,15 +1,13 @@
 '''API endpoints for AgMT app'''
 
-import requests
 from typing import List
 from fastapi import APIRouter, Query, Body, Depends, Request
-from starlette.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
 from dependencies import get_db, log
 import schemas
 import schemas_nlp
-from crud import nlp_crud, projects_crud, utils
+from crud import nlp_crud, projects_crud
 from custom_exceptions import GenericException
 from routers import content_apis
 
@@ -50,7 +48,7 @@ def update_project(request: Request, project_obj:schemas_nlp.TranslationProjectE
     log.debug('project_obj: %s',project_obj)
     if project_obj.selectedBooks:
         sentences = []
-        books_param_list = "" 
+        books_param_list = ""
         for buk in project_obj.selectedBooks.books:
             books_param_list += "&books=%s"%(buk)
         response = content_apis.extract_text_contents(

--- a/app/routers/translation_apis.py
+++ b/app/routers/translation_apis.py
@@ -3,6 +3,7 @@
 import requests
 from typing import List
 from fastapi import APIRouter, Query, Body, Depends, Request
+from starlette.responses import RedirectResponse
 from sqlalchemy.orm import Session
 
 from dependencies import get_db, log
@@ -51,14 +52,14 @@ def update_project(request: Request, project_obj:schemas_nlp.TranslationProjectE
         books_param_list = "" 
         for buk in project_obj.selectedBooks.books:
             books_param_list += "&books=%s"%(buk)
-        host = str(request.url).split('/v2/')[0]
-        response = requests.get(host+
-                '/v2/sources/get-sentence?source_name'+
+        url = request.url_for('extract_text_contents')
+        print(url)
+        response = requests.get(url+
+                '?source_name'+
                 '=%s%s'%(project_obj.selectedBooks.bible, books_param_list),
                 headers=request.headers).json()
         if "error" in response:
             raise GenericException(response['error'])
-        print(response)
         for item in response:
             sentences.append(utils.convert_dict_obj_to_pydantic(item, schemas_nlp.SentenceInput))
         if project_obj.sentenceList is not None:

--- a/app/routers/translation_apis.py
+++ b/app/routers/translation_apis.py
@@ -56,6 +56,7 @@ def update_project(request: Request, project_obj:schemas_nlp.TranslationProjectE
             source_name=project_obj.selectedBooks.bible,
             books=project_obj.selectedBooks.books,
             language_code=None,
+            content_type='bible',
             db_=db_)
         if "error" in response:
             raise GenericException(response['error'])

--- a/app/routers/translation_apis.py
+++ b/app/routers/translation_apis.py
@@ -60,7 +60,8 @@ def update_project(request: Request, project_obj:schemas_nlp.TranslationProjectE
         if "error" in response:
             raise GenericException(response['error'])
         for item in response:
-            sentences.append(schemas_nlp.SentenceInput(sentenceId=item[0], sentence=item[1]))
+            sentences.append(schemas_nlp.SentenceInput(
+                sentenceId=item[0], surrogateId=item[1], sentence=item[2]))
         if project_obj.sentenceList is not None:
             project_obj.sentenceList += sentences
         else:

--- a/app/routers/translation_apis.py
+++ b/app/routers/translation_apis.py
@@ -52,7 +52,6 @@ def update_project(request: Request, project_obj:schemas_nlp.TranslationProjectE
         for buk in project_obj.selectedBooks.books:
             books_param_list += "&books=%s"%(buk)
         host = str(request.url).split('/v2/')[0]
-        print(project_obj.selectedBooks.bible)
         response = requests.get(host+
                 '/v2/sources/get-sentence?source_name'+
                 '=%s%s'%(project_obj.selectedBooks.bible, books_param_list),

--- a/app/schemas_nlp.py
+++ b/app/schemas_nlp.py
@@ -75,13 +75,26 @@ class SelectedBooks(BaseModel):
     bible: TableNamePattern = Field(..., example='hi_IRV_1_bible')
     books: List[BookCodePattern]= Field(..., example=['luk', 'jhn'])
 
+class SentenceInput(BaseModel):
+    '''Input sentences for tokenization'''
+    sentenceId: str = Field(..., example=41001001)
+    sentence: str = Field(...,
+        example="इब्राहीम के वंशज दाऊद के पुत्र यीशु मसीह की वंशावली इस प्रकार है")
+    @root_validator
+    def set_surrogate_id(cls, values): # pylint: disable=R0201 disable=E0213
+        '''USFM and JSON should be updated together. If they are absent, bookCode is required'''
+        values['surrogateId'] = values['sentenceId']
+        values['sentenceId'] = int(values['sentenceId'])
+        return values
+
 class TranslationProjectEdit(BaseModel):
     '''New books to be added or active flag change'''
     projectId: int
     projectName: str = None
     active: bool = None
     selectedBooks: SelectedBooks = None
-    uploadedBooks: List[str] = None
+    uploadedUSFMs: List[str] = None
+    sentenceList: List[SentenceInput] = None
     useDataForLearning: bool = None
     stopwords: Stopwords = None
     punctuations: List[constr(max_length=1)] = None
@@ -145,18 +158,6 @@ class DraftInput(BaseModel):
     draftMeta: List[Tuple[Tuple[int, int], Tuple[int,int],'str']] = Field(None,
         example=[[[0,8], [0,8],"confirmed"],
             [[8,64],[8,64],"untranslated"]])
-    @root_validator
-    def set_surrogate_id(cls, values): # pylint: disable=R0201 disable=E0213
-        '''USFM and JSON should be updated together. If they are absent, bookCode is required'''
-        values['surrogateId'] = values['sentenceId']
-        values['sentenceId'] = int(values['sentenceId'])
-        return values
-
-class SentenceInput(BaseModel):
-    '''Input sentences for tokenization'''
-    sentenceId: str = Field(..., example=41001001)
-    sentence: str = Field(...,
-        example="इब्राहीम के वंशज दाऊद के पुत्र यीशु मसीह की वंशावली इस प्रकार है")
     @root_validator
     def set_surrogate_id(cls, values): # pylint: disable=R0201 disable=E0213
         '''USFM and JSON should be updated together. If they are absent, bookCode is required'''

--- a/app/schemas_nlp.py
+++ b/app/schemas_nlp.py
@@ -78,12 +78,14 @@ class SelectedBooks(BaseModel):
 class SentenceInput(BaseModel):
     '''Input sentences for tokenization'''
     sentenceId: str = Field(..., example=41001001)
+    surrogateId: str= Field(None, example="MAT 1:1")
     sentence: str = Field(...,
         example="इब्राहीम के वंशज दाऊद के पुत्र यीशु मसीह की वंशावली इस प्रकार है")
     @root_validator
     def set_surrogate_id(cls, values): # pylint: disable=R0201 disable=E0213
-        '''USFM and JSON should be updated together. If they are absent, bookCode is required'''
-        values['surrogateId'] = values['sentenceId']
+        '''Set surrogate id value, if not provided and make id int'''
+        if values['surrogateId'] is None:
+            values['surrogateId'] = values['sentenceId']
         values['sentenceId'] = int(values['sentenceId'])
         return values
 
@@ -151,6 +153,7 @@ class TranslateResponse(BaseModel):
 class DraftInput(BaseModel):
     '''Input sentences for translation'''
     sentenceId: str = Field(..., example=41001001)
+    surrogateId: str= Field(None, example="MAT 1:1")
     sentence: str = Field(...,
     	example="इब्राहीम के वंशज दाऊद के पुत्र यीशु मसीह की वंशावली इस प्रकार है")
     draft: str = Field(None,
@@ -160,8 +163,9 @@ class DraftInput(BaseModel):
             [[8,64],[8,64],"untranslated"]])
     @root_validator
     def set_surrogate_id(cls, values): # pylint: disable=R0201 disable=E0213
-        '''USFM and JSON should be updated together. If they are absent, bookCode is required'''
-        values['surrogateId'] = values['sentenceId']
+        '''Set surrogate id value, if not provided and make id int'''
+        if values['surrogateId'] is None:
+            values['surrogateId'] = values['sentenceId']
         values['sentenceId'] = int(values['sentenceId'])
         return values
 

--- a/app/test/test_agmt_projects.py
+++ b/app/test/test_agmt_projects.py
@@ -72,7 +72,7 @@ def test_default_post_put_get():
     # upload books
     put_data = {
     "projectId":new_project['projectId'],
-    "uploadedBooks":[bible_books['mat'], bible_books['mrk']]
+    "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
     response2 = client.put(UNIT_URL, headers=headers, json=put_data)
     assert response2.status_code == 201
@@ -248,12 +248,12 @@ def test_put_invalid():
     assert_input_validation_error(resp)
 
     data = {"projectId": new_project['projectId'],
-    "uploadedBooks": "mat"}
+    "uploadedUSFMs": "mat"}
     resp = client.put(UNIT_URL, headers=headers, json=data)
     assert_input_validation_error(resp)
 
     data = {"projectId": new_project['projectId'],
-    "uploadedBooks": ["The contents of matthew in text"]}
+    "uploadedUSFMs": ["The contents of matthew in text"]}
     resp = client.put(UNIT_URL, headers=headers, json=data)
     assert resp.status_code == 415
     assert resp.json()['error'] == "Not the Required Type"

--- a/app/test/test_agmt_translation.py
+++ b/app/test/test_agmt_translation.py
@@ -51,7 +51,7 @@ def test_get_tokens():
 
     put_data = {
         "projectId": project_id,
-        "uploadedBooks":[bible_books['mat'], bible_books['mrk']]
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
     resp = client.put("/v2/autographa/projects", headers=headers, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
@@ -181,7 +181,7 @@ def test_save_translation():
 
     put_data = {
         "projectId": project_id,
-        "uploadedBooks":[bible_books['mat'], bible_books['mrk']]
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
     resp = client.put("/v2/autographa/projects", headers=headers, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
@@ -248,7 +248,7 @@ def test_save_translation_invalid():
 
     put_data = {
         "projectId": project_id,
-        "uploadedBooks":[bible_books['mat'], bible_books['mrk']]
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
     resp = client.put("/v2/autographa/projects", headers=headers, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
@@ -329,7 +329,7 @@ def test_drafts():
 
     put_data = {
         "projectId": project_id,
-        "uploadedBooks":[bible_books['mat'], bible_books['mrk']]
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
     resp = client.put("/v2/autographa/projects", headers=headers, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
@@ -377,7 +377,7 @@ def test_get_token_sentences():
 
     put_data = {
         "projectId": project_id,
-        "uploadedBooks":[bible_books['mat'], bible_books['mrk']]
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
     resp = client.put("/v2/autographa/projects", headers=headers, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
@@ -439,7 +439,7 @@ def test_get_sentence():
 
     put_data = {
         "projectId": project_id,
-        "uploadedBooks":[bible_books['mat'], bible_books['mrk']]
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
     resp = client.put("/v2/autographa/projects", headers=headers, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
@@ -497,7 +497,7 @@ def test_progress_n_suggestion():
 
     put_data = {
         "projectId": project_id,
-        "uploadedBooks":[bible_books['mat'], bible_books['mrk']]
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
     resp = client.put("/v2/autographa/projects", headers=headers, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
@@ -563,7 +563,7 @@ def test_get_versification():
 
     put_data = {
         "projectId": project_id,
-        "uploadedBooks":[bible_books['mat'], bible_books['mrk']]
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
     resp = client.put("/v2/autographa/projects", headers=headers, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"

--- a/app/test/test_gql_agmt_projects.py
+++ b/app/test/test_gql_agmt_projects.py
@@ -178,7 +178,7 @@ def test_default_post_put_get():
     put_data = {
      "object": {
         "projectId":int(new_project['projectId']),
-        "uploadedBooks":[bible_books['mat'], bible_books['mrk']]
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
   }
 }  
 
@@ -403,7 +403,7 @@ def test_put_invalid():
     data = {
      "object": {
        "projectId": int(new_project['projectId']),
-        "uploadedBooks": "mat"
+        "uploadedUSFMs": "mat"
   }
 }
     executed1 = gql_request(query=PROJECT_EDIT_GLOBAL_QUERY,operation="mutation", variables=data)
@@ -412,7 +412,7 @@ def test_put_invalid():
     data = {
      "object": {
         "projectId": int(new_project['projectId']),
-    "uploadedBooks": ["The contents of matthew in text"]
+    "uploadedUSFMs": ["The contents of matthew in text"]
   }
 }
     executed1 = gql_request(query=PROJECT_EDIT_GLOBAL_QUERY,operation="mutation", variables=data)

--- a/app/test/test_gql_agmt_translation.py
+++ b/app/test/test_gql_agmt_translation.py
@@ -84,7 +84,7 @@ def test_get_tokens():
   put_data = {
      "object": {
         "projectId":int(new_project['projectId']),
-        "uploadedBooks":[bible_books['mat'], bible_books['mrk']]
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
   }
 }  
   executed2 = gql_request(query=PROJECT_EDIT_GLOBAL_QUERY,operation="mutation", variables=put_data)
@@ -307,7 +307,7 @@ def create_project_get_alltoken():
   put_data = {
      "object": {
         "projectId":int(project_id),
-        "uploadedBooks":[bible_books['mat'], bible_books['mrk']]
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
   }
 }  
   executed = gql_request(query=PROJECT_EDIT_GLOBAL_QUERY,operation="mutation", variables=put_data)
@@ -708,7 +708,7 @@ def test_progress_n_suggestion():
   put_data = {
      "object": {
         "projectId":int(project_id),
-        "uploadedBooks":[bible_books['mat'], bible_books['mrk']]
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
   }
 }  
   executed = gql_request(query=PROJECT_EDIT_GLOBAL_QUERY,operation="mutation", variables=put_data)

--- a/app/test/test_gql_translation_workflow.py
+++ b/app/test/test_gql_translation_workflow.py
@@ -117,7 +117,7 @@ def test_end_to_end_translation():
     project_update_data = {
      "object": {
         "projectId":project_id,
-        "uploadedBooks":[bible_books['mat'], bible_books['mrk']],
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']],
         "selectedBooks": {
             "bible": source_name,
             "books": ["luk", "jhn"]

--- a/app/test/test_source_get_sentence.py
+++ b/app/test/test_source_get_sentence.py
@@ -1,0 +1,187 @@
+'''Test cases for versions related APIs'''
+from . import client
+from . import assert_input_validation_error, assert_not_available_content
+from . import check_default_get
+from .test_versions import check_post as add_version
+from .test_sources import check_post as add_source
+from .test_bibles import gospel_books_data
+
+UNIT_URL = 'v2/sources/'
+SENT_URL = UNIT_URL+ "get-sentence"
+headers = {"contentType": "application/json", "accept": "application/json"}
+
+def assert_positive_get(item):
+    '''Check for properties a normal sentence response will have'''
+    assert "sentenceId" in item
+    assert isinstance(item['sentenceId'], int)
+    assert "surrogateId" in item
+    assert isinstance(item['surrogateId'], str)
+    assert "sentence" in item
+
+commentary_data = [
+        {'bookCode':'gen', 'chapter':0, 'commentary':'book intro to Genesis'},
+        {'bookCode':'gen', 'chapter':1, 'verseStart':0, 'verseEnd': 0,
+            'commentary':'chapter intro to Genesis 1'},
+        {'bookCode':'gen', 'chapter':1, 'verseStart':1, 'verseEnd': 10,
+            'commentary':'the begining'},
+        {'bookCode':'gen', 'chapter':1, 'verseStart':3, 'verseEnd': 30,
+            'commentary':'the creation'},
+        {'bookCode':'gen', 'chapter':1, 'verseStart':-1, 'verseEnd': -1,
+            'commentary':'Chapter Epilogue. God completes creation in 6 days.'},
+        {'bookCode':'gen', 'chapter':-1, 'commentary':'book Epilogue.'},
+
+        {'bookCode':'exo', 'chapter':1, 'verseStart':1,
+            "verseEnd":1, 'commentary':'first verse of Exodus'},
+        {'bookCode':'exo', 'chapter':1, 'verseStart':1,
+        "verseEnd":10, 'commentary':'first para of Exodus'},
+        {'bookCode':'exo', 'chapter':1, 'verseStart':1,
+        "verseEnd":25, 'commentary':'first few paras of Exodus'},
+        {'bookCode':'exo', 'chapter':1, 'verseStart':20,
+        "verseEnd":25, 'commentary':'a middle para of Exodus'},
+        {'bookCode':'exo', 'chapter':0, 'commentary':'Book intro to Exodus'}
+    ]
+
+
+def create_sources():
+    '''prior steps and post attempt, without checking the response'''
+    version_data = {
+        "versionAbbreviation": "TTT",
+        "versionName": "test version for get sentence",
+    }
+    add_version(version_data)
+    source_data = {
+        "contentType": "bible",
+        "language": "hi",
+        "version": "TTT",
+        "year": 2020,
+        "revision": 1
+    }
+    source = add_source(source_data)
+    bible_name = source.json()['data']['sourceName']
+    resp = client.post(f'/v2/bibles/{bible_name}/books', headers=headers, json=gospel_books_data)
+    assert resp.status_code == 201
+
+    source_data = {
+        "contentType": "commentary",
+        "language": "en",
+        "version": "TTT",
+        "year": 2020,
+        "revision": 1
+    }
+    source = add_source(source_data)
+    commentary_name = source.json()['data']['sourceName']
+    resp = client.post(f'/v2/commentaries/{commentary_name}', headers=headers, json=commentary_data)
+    assert resp.status_code == 201
+
+    return bible_name, commentary_name
+
+def test_get_poisitive():
+	'''normal tests for all possible get queries'''
+
+	# Before adding data
+	resp = client.get(SENT_URL+"?source_name=hi_TTT_1_bible", headers=headers)
+	assert resp.status_code == 404
+
+	# Add data
+	bible_name, commentary_name = create_sources()
+
+	check_default_get(SENT_URL, assert_positive_get)
+
+	# filtering with various params
+	resp = client.get(SENT_URL, headers=headers)
+	assert resp.status_code == 200
+	full_resp = resp.json()
+	for item in full_resp:
+		assert_positive_get(item)
+
+	resp = client.get(SENT_URL+"?language_code=hi", headers=headers)
+	assert resp.status_code == 200
+	only_hi = resp.json()
+	for item in only_hi:
+		assert_positive_get(item)
+	assert 0 < len(only_hi) < len(full_resp)
+
+	resp = client.get(SENT_URL+"?content_type=commentary", headers=headers)
+	assert resp.status_code == 200
+	only_commentary = resp.json()
+	for item in only_commentary:
+		assert_positive_get(item)
+	assert 0 < len(only_commentary) < len(full_resp)
+
+	resp = client.get(SENT_URL+'?source_name='+bible_name, headers=headers)
+	assert resp.status_code == 200
+	chosen_bible = resp.json()
+	assert len(chosen_bible) == 8
+	for item in chosen_bible:
+		assert_positive_get(item)
+
+	resp = client.get(SENT_URL+'?source_name='+commentary_name, headers=headers)
+	assert resp.status_code == 200
+	chosen_commentary = resp.json()
+	assert len(chosen_commentary) == 11
+	for item in chosen_commentary:
+		assert_positive_get(item)
+
+	for buk in ['mat','mrk','luk','jhn']:
+		resp = client.get(SENT_URL+'?source_name='+bible_name+'&books='+buk, headers=headers)
+		assert resp.status_code == 200
+		chosen_book = resp.json()
+		assert len(chosen_book) == 2
+		for item in chosen_book:
+			assert_positive_get(item)
+
+
+	resp = client.get(SENT_URL+'?source_name='+commentary_name+'&books=gen', headers=headers)
+	assert resp.status_code == 200
+	chosen_book = resp.json()
+	assert len(chosen_book) == 6
+	for item in chosen_book:
+		assert_positive_get(item)
+
+	resp = client.get(SENT_URL+'?source_name='+commentary_name+'&books=exo', headers=headers)
+	assert resp.status_code == 200
+	chosen_book = resp.json()
+	assert len(chosen_book) == 5
+	for item in chosen_book:
+		assert_positive_get(item)
+
+def test_get_negatives():
+	'''error or not available cases'''
+	# Add data
+	bible_name, commentary_name = create_sources()
+
+	for buk in ['mat','mrk','luk','jhn']:
+		resp = client.get(SENT_URL+'?source_name='+commentary_name+'&books='+buk, headers=headers)
+		assert_not_available_content(resp)
+
+	for buk in ['gen', 'exo']:
+		resp = client.get(SENT_URL+'?source_name='+bible_name+'&books='+buk, headers=headers)
+		assert_not_available_content(resp)
+
+	# wrong source_name
+	resp = client.get(SENT_URL+'?source_name='+bible_name.replace('bible','commentary')+'&books=mat', headers=headers)
+	assert resp.status_code == 404
+
+	# wrong content
+	resp = client.get(SENT_URL+'?content_type=usfm&books=mat', headers=headers)
+	assert resp.status_code == 404
+
+	# wrong lang
+	resp = client.get(SENT_URL+'?language_code=ur', headers=headers)
+	assert resp.status_code == 404
+
+	# worng pattern for book
+	resp = client.get(SENT_URL+'?books=matthew', headers=headers)
+	assert_input_validation_error(resp)
+
+	# worng pattern for source
+	resp = client.get(SENT_URL+'?source_name=bible', headers=headers)
+	assert_input_validation_error(resp)
+
+	# worng pattern for lang
+	resp = client.get(SENT_URL+'?language_code="hindi or malayalam"', headers=headers)
+	assert_input_validation_error(resp)
+
+
+	# worng pattern for book
+

--- a/app/test/test_translation_workflow.py
+++ b/app/test/test_translation_workflow.py
@@ -199,7 +199,7 @@ bible_books = {
 
 project_update_data = {
 	"projectId":project_id,
-    "uploadedBooks":[bible_books['mat'], bible_books['mrk']],
+    "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']],
     "selectedBooks":{"bible": source_name,
     				 "books": ['luk', 'jhn']}
 


### PR DESCRIPTION
* adds a new API `GET /v2/sources/get-sentence` that can be used to extract text contents from multiple tables of different types. Currently supports bible and commentary
* Have filters for language, content_type, specific source and books
* Returns list of (sentenceId, surrogateId, sentence)
```
[
  {
    "sentenceId": 41001001,
    "surrogateId": "mat 1:1",
    "sentence": "test verse one"
  },
  {
    "sentenceId": 1000023,
    "surrogateId": "gen 1:1-10",
    "sentence": "commentary"
  }
] 
```
* Uses this function for adding books to an AgMT project
* The same function can be used for getting corpus in SW identification or other NLP tasks
* Implemented in a way, access-right based filtering of source contents can be handled when accessed from other APIs like project update or SW identification