### PR TITLE
Bugfix/languages search

### DIFF
--- a/app/crud/structurals_crud.py
+++ b/app/crud/structurals_crud.py
@@ -41,7 +41,7 @@ def get_languages(db_: Session, language_code = None, language_name = None, sear
     if language_name:
         query = query.filter(func.lower(db_models.Language.language) == language_name.lower())
     if search_word:
-        search_pattern = re.sub(r'\s+', " & ", search_word)
+        search_pattern = " & ".join(re.findall(r'\w+', search_word))
         search_pattern += ":*"
         query = query.filter(text("to_tsvector(language_code || ' ' || language_name || ' ' || "+\
             "jsonb_to_tsvector('simple', metadata, '[\"string\", \"numeric\"]') || ' ')"+\

--- a/app/crud/structurals_crud.py
+++ b/app/crud/structurals_crud.py
@@ -43,7 +43,8 @@ def get_languages(db_: Session, language_code = None, language_name = None, sear
     if search_word:
         search_pattern = " & ".join(re.findall(r'\w+', search_word))
         search_pattern += ":*"
-        query = query.filter(text("to_tsvector(language_code || ' ' || language_name || ' ' || "+\
+        query = query.filter(text("to_tsvector('simple', language_code || ' ' ||"+\
+            " language_name || ' ' || "+\
             "jsonb_to_tsvector('simple', metadata, '[\"string\", \"numeric\"]') || ' ')"+\
             " @@ to_tsquery('simple', :pattern)").bindparams(pattern=search_pattern))
     if language_id is not None:

--- a/app/test/test_languages.py
+++ b/app/test/test_languages.py
@@ -209,3 +209,7 @@ def test_searching():
         if lang['language'] == "Sinhala":
             found = True
     assert found    
+
+    # ensure search words are not stemmed as per rules of english
+    response = client.get(UNIT_URL+"?search_word=chinese")
+    assert len(response.json()) > 5

--- a/app/test/test_languages.py
+++ b/app/test/test_languages.py
@@ -190,3 +190,22 @@ def test_searching():
         if lang['language'] == "Sinhala":
             found = True
     assert found    
+
+    # search word with special symbols in them
+    response = client.get(UNIT_URL+"?search_word=sri%20lanka(Asia)")
+    assert len(response.json()) > 0
+    found = False
+    for lang in response.json():
+        assert_positive_get(lang)
+        if lang['language'] == "Sinhala":
+            found = True
+    assert found    
+
+    response = client.get(UNIT_URL+"?search_word=sri-lanka-asia!")
+    assert len(response.json()) > 0
+    found = False
+    for lang in response.json():
+        assert_positive_get(lang)
+        if lang['language'] == "Sinhala":
+            found = True
+    assert found    


### PR DESCRIPTION
Fixes for #278 and #279 

Causes: 
1. search words were used to create a ts query pattern which miss behaved when there were special symbols like paranthesis among query words
2. Search word was being stemmed by some default rules and chinese became chines and wasn't returning expected results. 