### PR TITLE
Fix issues in auth for apis with multiple permissions

### DIFF
--- a/app/auth/access_rules.json
+++ b/app/auth/access_rules.json
@@ -3,6 +3,7 @@
         "create": ["registeredUser"],
         "edit":["SuperAdmin", "resourceCreatedUser"],
         "read-via-api":["noAuthRequired"],
+        "read-via-vachanadmin":["SuperAdmin", "VachanAdmin"],
         "view-on-web":["noAuthRequired"],
         "refer-for-translation": ["registeredUser"]
     },
@@ -49,7 +50,7 @@
         "edit":["registeredUser"]
     },
     "research-use":{
-        "read":["SuperAdmin", "BcsDeveloper"]
+        "read-via-api":["SuperAdmin", "BcsDeveloper"]
     },
     "user":{
         "create":["noAuthRequired"],

--- a/app/auth/api-permissions.csv
+++ b/app/auth/api-permissions.csv
@@ -33,10 +33,11 @@ Endpoints,Method,RequestApp,FilterResults,ResourceType,Permission
 /v2/sources,GET,API-user,True,None,read-via-api
 /v2/sources,POST,None,False,None,create
 /v2/sources,PUT,None,False,None,edit
-/v2/sources/get-sentence,GET,Autographa,False,None,refer-for-translation
-/v2/sources/get-sentence,GET,Vachan-online or vachan-app,False,None,view-on-web
-/v2/sources/get-sentence,GET,VachanAdmin,False,None,read-via-vachanadmin
-/v2/sources/get-sentence,GET,API-user,False,None,read-via-api
+/v2/sources/get-sentence,GET,Autographa,False,"contents like bibles, commentaries, infographics, dictionary or videos",refer-for-translation
+/v2/sources/get-sentence,GET,Vachan-online or vachan-app,False,"contents like bibles, commentaries, infographics, dictionary or videos",view-on-web
+/v2/sources/get-sentence,GET,VachanAdmin,False,"contents like bibles, commentaries, infographics, dictionary or videos",read-via-vachanadmin
+/v2/sources/get-sentence,GET,API-user,False,"contents like bibles, commentaries, infographics, dictionary or videos",read-via-api
+/v2/sources/get-sentence,GET,None,False,Research-Material,read-via-api
 /v2/lookup/bible/books,GET,None,False,None,read
 /v2/bibles/{source_name}/books,GET,Autographa,False,None,refer-for-translation
 /v2/bibles/{source_name}/books,GET,Vachan-online or vachan-app,False,None,view-on-web
@@ -100,7 +101,8 @@ Endpoints,Method,RequestApp,FilterResults,ResourceType,Permission
 /v2/translation/tokens,PUT,None,False,None,process
 /v2/translation/token-translate,PUT,None,False,None,process
 /v2/translation/draft,PUT,None,False,None,process
-/v2/translation/stopwords/generate,POST,None,False,None,read
+/v2/translation/stopwords/generate,POST,None,False,Lookup contents,create
+/v2/translation/stopwords/generate,POST,None,False,"contents like bibles, commentaries, infographics, dictionary or videos",read-via-api
 /v2/lookup/stopwords/{language_code},GET,None,False,None,read
 /v2/lookup/stopwords/{language_code},PUT,None,False,None,edit
 /v2/lookup/stopwords/{language_code},POST,None,False,None,create

--- a/app/crud/nlp_sw_crud.py
+++ b/app/crud/nlp_sw_crud.py
@@ -181,7 +181,7 @@ async def filter_translation_words(db_, request, gl_lang_code, stopwords, user_d
             skip=0, limit=100000,
             user_details=user_details,
             db_=db_, operates_on=schema_auth.ResourceType.CONTENT.value)
-    except Exception as exe:
+    except Exception as exe: #pylint: disable=W0703
         log.exception(exe)
         log.error("Error in accessing translation_words")
         response = None

--- a/app/crud/nlp_sw_crud.py
+++ b/app/crud/nlp_sw_crud.py
@@ -12,7 +12,7 @@ from custom_exceptions import NotAvailableException
 
 import db_models
 from dependencies import log
-from schema import schemas_nlp
+from schema import schemas_nlp, schema_auth
 from crud import utils
 from routers import content_apis
 
@@ -135,7 +135,7 @@ async def get_data(db_, request, language_code, sentence_list, **kwargs):
             content_type=None,
             skip=0, limit=100000,
             user_details=kwargs.get('user_details'),
-            db_=db_)
+            db_=db_, operates_on=schema_auth.ResourceType.CONTENT.value)
         if server_data:
             if "error" not in server_data:
                 sentences += [item[2] for item in server_data]
@@ -171,15 +171,20 @@ async def filter_translation_words(db_, request, gl_lang_code, stopwords, user_d
                 %gl_lang_code)
     gl_id = gl_id[0]
     source_name = tw_lookup[gl_lang_code]
-    response = await content_apis.get_dictionary_word(
-        request=request, #pylint: disable=W0613
-        source_name=source_name,
-        search_word =None,
-        details=None,
-        active=True,
-        skip=0, limit=100000,
-        user_details=user_details,
-        db_=db_)
+    try:
+        response = await content_apis.get_dictionary_word(
+            request=request, #pylint: disable=W0613
+            source_name=source_name,
+            search_word =None,
+            details=None,
+            active=True,
+            skip=0, limit=100000,
+            user_details=user_details,
+            db_=db_, operates_on=schema_auth.ResourceType.CONTENT.value)
+    except Exception as exe:
+        log.exception(exe)
+        log.error("Error in accessing translation_words")
+        response = None
     if response:
         translation_words = [row.word for row in response]
         translation_words = [item.strip() for item in translation_words if item.strip()!='']
@@ -296,7 +301,7 @@ async def generate_stopwords(db_: Session, request: Request, *args, user_details
         sentences = await get_data(db_, request, language_code, sentence_list, **kwargs)
     except Exception as exe: #pylint: disable=W0703
         log.error("Error in getting sentences for SW generation")
-        log.error(str(exe))
+        log.exception(exe)
 
     if len(sentences) < 1000:
         # raise UnprocessableException("Not enough data to generate stopwords")
@@ -319,7 +324,7 @@ async def generate_stopwords(db_: Session, request: Request, *args, user_details
             update_args = {
                         "status" : schemas_nlp.JobStatus.FINISHED.value,
                         "endTime": datetime.now(),
-                        "output": {"message": exe.name, "language": language_code,"data": exe}
+                        "output": {"message": "Error", "language": language_code,"data": exe}
                     }
     update_job(db_, job_id, user_id, update_args)
 

--- a/app/graphql_api/mutations.py
+++ b/app/graphql_api/mutations.py
@@ -1322,7 +1322,8 @@ class GenerateStopwords(graphene.Mutation):
         response = await translation_apis.generate_stopwords(request=req,
             language_code=language_code,background_tasks=background_tasks,
             use_server_data=use_server_data,gl_lang_code=gl_lang_code,
-            user_details=user_details,sentence_list=sentence_list,db_=db_)
+            user_details=user_details,sentence_list=sentence_list,db_=db_,
+            operates_on=schema_auth.ResourceType.LOOKUP.value)
         return GenerateStopwords(message=response['message'],
             data=response["data"])
 

--- a/app/graphql_api/queries.py
+++ b/app/graphql_api/queries.py
@@ -94,7 +94,7 @@ class Query(graphene.ObjectType):
         language_code=graphene.String(
             description="language code as per bcp47(usually 2 letter code)"),
         license_code=graphene.String(),
-        access_tag = graphene.List(types.SourcePermissions),
+        access_tag = graphene.List(graphene.String),
         active=graphene.Boolean(), latest_revision=graphene.Boolean(),
         skip=graphene.Int(), limit=graphene.Int())
     def resolve_contents(self, info, content_type=None, version_abbreviation=None,#pylint: disable=too-many-locals
@@ -117,7 +117,7 @@ class Query(graphene.ObjectType):
         version_abbreviation=version_abbreviation, revision=revision, language_code=language_code
         ,license_code=license_code, metadata=metadata, access_tag=access_tag, active=active,
         latest_revision=latest_revision, skip=skip, limit=limit, user_details=user_details,
-        db_=db_)
+        db_=db_, filtering_required=True)
         return results
 
     bible_books = graphene.List(types.BibleBook,
@@ -300,7 +300,7 @@ class Query(graphene.ObjectType):
         results = translation_apis.get_projects(request= req,
             project_name=project_name, source_language=source_language,
             target_language=target_language, active=active, user_id=user_id,
-            skip= skip, limit= limit, user_details =user_details, db_=db_)
+            skip= skip, limit= limit, user_details =user_details, db_=db_, filtering_required=True)
         return results
 
     agmt_project_tokens = graphene.List(types.Token,

--- a/app/graphql_api/types.py
+++ b/app/graphql_api/types.py
@@ -401,7 +401,7 @@ class InputAddSource(graphene.InputObjectType):
     year = graphene.Int(required=True)
     license = graphene.String(default_value = "CC-BY-SA",\
         description="pattern: ^[a-zA-Z0-9\\.\\_\\-]+$")
-    accessPermissions = graphene.List(SourcePermissions,
+    accessPermissions = graphene.List(graphene.String,
         default_value = [SourcePermissions.CONTENT.value])#pylint: disable=no-member
     metaData = graphene.JSONString(description="Expecting a dictionary Type JSON String",
         default_value = {})
@@ -417,7 +417,7 @@ class InputEditSource(graphene.InputObjectType):
     revision = graphene.String(description="default: 1")
     year = graphene.Int()
     license = graphene.String(description="pattern: ^[a-zA-Z0-9\\.\\_\\-]+$")
-    accessPermissions = graphene.List(SourcePermissions,
+    accessPermissions = graphene.List(graphene.String,
         default_value = [SourcePermissions.CONTENT.value])#pylint: disable=no-member
     metaData = graphene.JSONString(description="Expecting a dictionary Type JSON String",
         default_value = {})

--- a/app/routers/auth_api.py
+++ b/app/routers/auth_api.py
@@ -23,7 +23,7 @@ responses={400: {"model": schemas.ErrorResponse}},
 status_code=201,tags=["Authentication"])
 @get_auth_access_check_decorator
 async def register(register_details:schema_auth.Registration,request: Request,#pylint: disable=unused-argument
-app_type: schema_auth.App=Query(schema_auth.App.API),user_details =Depends(get_user_or_none),#pylint: disable=unused-argument
+app_type: schema_auth.AppInput=Query(schema_auth.App.API),user_details =Depends(get_user_or_none),#pylint: disable=unused-argument
 db_: Session = Depends(get_db)):#pylint: disable=unused-argument
     '''Registration for Users
     * user_email and password fiels are mandatory

--- a/app/routers/content_apis.py
+++ b/app/routers/content_apis.py
@@ -230,7 +230,7 @@ async def edit_version(request: Request, ver_obj: schemas.VersionEdit = Body(...
     responses={502: {"model": schemas.ErrorResponse},
     422: {"model": schemas.ErrorResponse}}, status_code=200, tags=["Sources"])
 @get_auth_access_check_decorator
-async def get_source(request: Request,content_type: str=Query(None, example="commentary"),
+async def get_source(request: Request,content_type: str=Query(None, example="commentary"), #pylint: disable=too-many-locals
     version_abbreviation: schemas.VersionPattern=Query(None,example="KJV"),
     revision: int=Query(None, example=1),
     language_code: schemas.LangCodePattern=Query(None,example="en"),

--- a/app/routers/translation_apis.py
+++ b/app/routers/translation_apis.py
@@ -3,7 +3,6 @@
 from typing import List
 from fastapi import APIRouter, Query, Body, Depends, Request, Path, BackgroundTasks
 from sqlalchemy.orm import Session
-from starlette.datastructures import URL
 
 
 from dependencies import get_db, log

--- a/app/routers/translation_apis.py
+++ b/app/routers/translation_apis.py
@@ -7,7 +7,7 @@ from starlette.datastructures import URL
 
 
 from dependencies import get_db, log
-from schema import schemas, schemas_nlp
+from schema import schemas, schemas_nlp, schema_auth
 from crud import nlp_crud, projects_crud, nlp_sw_crud
 from custom_exceptions import GenericException
 from routers import content_apis
@@ -25,7 +25,8 @@ async def get_projects(request: Request,
     target_language:schemas.LangCodePattern=Query(None,example='ml'),
     active:bool=True, user_id:str=Query(None),
     skip: int=Query(0, ge=0), limit: int=Query(100, ge=0),
-    user_details =Depends(get_user_or_none), db_:Session=Depends(get_db)):
+    user_details =Depends(get_user_or_none), db_:Session=Depends(get_db),
+    filtering_required=True):
     '''Fetches the list of proejct and their details'''
     log.info('In get_projects')
     log.debug('project_name: %s, source_language:%s, target_language:%s,\
@@ -52,7 +53,8 @@ async def create_project(request: Request,
     tags=['Autographa-Project management'])
 @get_auth_access_check_decorator
 async def update_project(request: Request, project_obj:schemas_nlp.TranslationProjectEdit,
-    user_details =Depends(get_user_or_none), db_:Session=Depends(get_db)):
+    user_details =Depends(get_user_or_none), db_:Session=Depends(get_db),
+    operates_on=schema_auth.ResourceType.PROJECT.value):
     '''Adds more books to a autographa MT project's source. Delete or activate project.'''
     log.info('In update_project')
     log.debug('project_obj: %s',project_obj)
@@ -62,8 +64,8 @@ async def update_project(request: Request, project_obj:schemas_nlp.TranslationPr
         for buk in project_obj.selectedBooks.books:
             books_param_list += "&books=%s"%(buk)
 
-        request.scope['method'] = 'GET'
-        request._url = URL('/v2/sources')#pylint: disable=protected-access
+        # request.scope['method'] = 'GET'
+        # request._url = URL('/v2/sources')#pylint: disable=protected-access
         response = await content_apis.extract_text_contents(
             request=request,
             source_name=project_obj.selectedBooks.bible,
@@ -436,7 +438,8 @@ async def generate_stopwords(request: Request, background_tasks: BackgroundTasks
     language_code:schemas.LangCodePattern=Query(...,example="bi"),
     use_server_data:bool=True, gl_lang_code:schemas.LangCodePattern=Query(None,example="hi"),
     user_details =Depends(get_user_or_none),
-    sentence_list:List[schemas_nlp.SentenceInput]=Body(None), db_:Session=Depends(get_db)):
+    sentence_list:List[schemas_nlp.SentenceInput]=Body(None), db_:Session=Depends(get_db),
+    operates_on=schema_auth.ResourceType.LOOKUP.value):
     '''Auto generate stop words for a given language'''
     log.info('In generate_stopwords')
     log.debug('language_code:%s, use_server_data:%s, gl_lang_code:%s, sentence_list:%s',

--- a/app/schema/schema_auth.py
+++ b/app/schema/schema_auth.py
@@ -12,13 +12,20 @@ class ResourceType(str, Enum):
     USER = "all users in our system (Kratos)"
     TRANSLATION = "generic translation apis"
     LOOKUP = "Lookup contents"
+    RESEARCH = "Research-Material"
 
 class App(str, Enum):
     '''Defined apps'''
     AG = "Autographa"
     VACHAN = "Vachan-online or vachan-app"
     API = "API-user"
-# VACHANADMIN = "VachanAdmin"
+    VACHANADMIN = "VachanAdmin"
+
+class AppInput(str, Enum):
+    '''Input fields for App in Registration'''
+    AG = "Autographa"
+    VACHAN = "Vachan-online or vachan-app"
+    API = "API-user"
 
 class Registration(BaseModel):
     """kratos registration input"""

--- a/app/test/__init__.py
+++ b/app/test/__init__.py
@@ -906,7 +906,11 @@ def contetapi_get_accessrule_checks_app_userroles_gql(contenttype, content_qry, 
                 "accept": "application/json"}
     #create 5 sources for contents with 5 different permisions
     language_list = ['en','ml','tn','ab','af']
-    permission_list = ["CONTENT","OPENACCESS","PUBLISHABLE","DOWNLOADABLE","DERIVABLE"]
+    permission_list = [types.SourcePermissions.CONTENT.value,
+        types.SourcePermissions.OPENACCESS.value,
+        types.SourcePermissions.PUBLISHABLE.value ,
+        types.SourcePermissions.DOWNLOADABLE.value,
+        types.SourcePermissions.DERIVABLE.value]
     permission_list_val = ["content","open-access","publishable","downloadable","derivable"]
     sourcename_list = []
 

--- a/app/test/test_gql_agmt_projects.py
+++ b/app/test/test_gql_agmt_projects.py
@@ -13,6 +13,7 @@ from .test_gql_versions import check_post as version_add
 from .test_gql_sources import check_post as source_add
 from .conftest import initial_test_users
 from app.graphql_api import types
+from app.schema import schemas
 from . test_gql_auth_basic import login,SUPER_PASSWORD,SUPER_USER
 
 headers_auth = {"contentType": "application/json",
@@ -156,7 +157,7 @@ def check_post(query,variables):
   """positive post test"""
   headers_auth = {"contentType": "application/json",
               "accept": "application/json",
-              "app":"Autographa"}
+              "App":"Autographa"}
   headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
   #without Auth
   executed = gql_request(query=query,operation="mutation", variables=variables)
@@ -184,6 +185,8 @@ agmtProjects(projectName:"Test project 1"){
   executed = gql_request(query=get_non_exisitng_project)
   assert "errors" in executed
   #with auth
+  headers_auth["app"] = types.App.AG.value
+  headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
   executed = gql_request(query=get_non_exisitng_project,headers=headers_auth)
   assert_not_available_content_gql(executed["data"]["agmtProjects"])
 
@@ -205,8 +208,6 @@ agmtProjects(projectName:"Test project 1"){
 
 
   #Get created project
-  headers_auth["app"] = types.App.AG.value
-  headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
   get_query_projectname = """
     query agmtfetch($projectname:String){
 agmtProjects(projectName:$projectname){
@@ -268,7 +269,8 @@ agmtProjects(projectName:$projectname){
     "version": "TTT",
     "year": 2020,
     "accessPermissions": [
-      "CONTENT","OPENACCESS"
+      types.SourcePermissions.CONTENT.value,
+      types.SourcePermissions.OPENACCESS.value
     ],
   }
 }

--- a/app/test/test_gql_sources.py
+++ b/app/test/test_gql_sources.py
@@ -1,6 +1,7 @@
 """Test cases for Sources in GQL"""
 from typing import Dict
 
+from app.schema import schema_auth
 from app.graphql_api import types
 #pylint: disable=E0401
 from .test_sources import assert_positive_get
@@ -14,7 +15,7 @@ from .conftest import initial_test_users
 from . test_gql_auth_basic import login,SUPER_PASSWORD,SUPER_USER
 
 headers_auth = {"contentType": "application/json",
-                "accept": "application/json"}
+                "accept": "application/json", "App":schema_auth.App.VACHANADMIN.value}
 headers = {"contentType": "application/json", "accept": "application/json"}
 
 SOURCE_GLOBAL_VARIABLES = {
@@ -71,6 +72,7 @@ headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['VachanAdmin']['
 
 def check_post(query,variables):
     """positive post test"""
+    headers_auth['App'] = schema_auth.App.VACHANADMIN.value
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['VachanAdmin']['token']
     #without auth
     executed = gql_request(query=query,operation="mutation", variables=variables)
@@ -834,7 +836,7 @@ def test_get_source_filter_access_tag():
     "version": "TTT",
     "year": 2020,
     "accessPermissions": [
-      "CONTENT"
+      types.SourcePermissions.CONTENT.value
     ],
   }
 }
@@ -842,15 +844,15 @@ def test_get_source_filter_access_tag():
     check_post(SOURCE_GLOBAL_QUERY,source_data)
 
     source_data["object"]['language'] = 'mr'
-    source_data["object"]['accessPermissions'] = ["OPENACCESS"]
+    source_data["object"]['accessPermissions'] = [types.SourcePermissions.OPENACCESS.value]
     check_post(SOURCE_GLOBAL_QUERY,source_data)
 
     source_data["object"]['language'] = 'te'
-    source_data["object"]['accessPermissions'] = ["PUBLISHABLE"]
+    source_data["object"]['accessPermissions'] = [types.SourcePermissions.PUBLISHABLE.value]
     check_post(SOURCE_GLOBAL_QUERY,source_data)
 
     get_qry = """
-      query get_source($obj:[SourcePermissions],$ver:String){
+      query get_source($obj:[String],$ver:String){
   contents(accessTag:$obj,versionAbbreviation:$ver){
     sourceName
   }
@@ -858,7 +860,7 @@ def test_get_source_filter_access_tag():
     """
     get_var = {
     "obj": [
-    "CONTENT"
+    types.SourcePermissions.CONTENT.value
   ],
   "ver": "TTT"
 }
@@ -866,17 +868,17 @@ def test_get_source_filter_access_tag():
     assert isinstance(executed1, Dict)
     assert len(executed1["data"]["contents"]) >= 3
 
-    get_var["obj"] = ["OPENACCESS"]
+    get_var["obj"] = [types.SourcePermissions.OPENACCESS.value]
     executed2 = gql_request(query=get_qry,variables=get_var, headers=headers_auth)
     assert isinstance(executed2, Dict)
     assert len(executed2["data"]["contents"]) >= 1
 
-    get_var["obj"] = ["PUBLISHABLE"]
+    get_var["obj"] = [types.SourcePermissions.PUBLISHABLE.value]
     executed3 = gql_request(query=get_qry,variables=get_var, headers=headers_auth)
     assert isinstance(executed3, Dict)
     assert len(executed3["data"]["contents"]) >= 1
 
-    get_var["obj"] = ["PUBLISHABLE","OPENACCESS"]
+    get_var["obj"] = [types.SourcePermissions.PUBLISHABLE.value,types.SourcePermissions.OPENACCESS.value]
     executed4 = gql_request(query=get_qry,variables=get_var, headers=headers_auth,)
     assert_not_available_content_gql(executed4["data"]["contents"])
 
@@ -1210,7 +1212,7 @@ def test_diffrernt_sources_with_app_and_roles():
     "version": "TTT",
     "year": 2020,
     "accessPermissions": [
-      "CONTENT"
+      types.SourcePermissions.CONTENT.value
     ],
   }
 }
@@ -1220,7 +1222,7 @@ def test_diffrernt_sources_with_app_and_roles():
 
     #open-access
     source_data["object"]["language"] = 'ml'
-    source_data["object"]["accessPermissions"] = ["OPENACCESS"]
+    source_data["object"]["accessPermissions"] = [types.SourcePermissions.OPENACCESS.value]
     resposne = check_post(SOURCE_GLOBAL_QUERY,source_data)
     resp_data = resposne["data"]["addSource"]["data"]["metaData"]
     assert resp_data["accessPermissions"] == \
@@ -1228,7 +1230,7 @@ def test_diffrernt_sources_with_app_and_roles():
 
     #publishable
     source_data["object"]["language"] = 'tn'
-    source_data["object"]["accessPermissions"] = ["PUBLISHABLE"]
+    source_data["object"]["accessPermissions"] = [types.SourcePermissions.PUBLISHABLE.value]
     resposne = check_post(SOURCE_GLOBAL_QUERY,source_data)
     resp_data = resposne["data"]["addSource"]["data"]["metaData"]
     assert resp_data["accessPermissions"] == \
@@ -1236,7 +1238,7 @@ def test_diffrernt_sources_with_app_and_roles():
 
     #downloadable
     source_data["object"]["language"] = 'af'
-    source_data["object"]["accessPermissions"] = ["DOWNLOADABLE"]
+    source_data["object"]["accessPermissions"] = [types.SourcePermissions.DOWNLOADABLE.value]
     resposne = check_post(SOURCE_GLOBAL_QUERY,source_data)
     resp_data = resposne["data"]["addSource"]["data"]["metaData"]
     assert resp_data["accessPermissions"] == \
@@ -1244,7 +1246,7 @@ def test_diffrernt_sources_with_app_and_roles():
 
     #derivable
     source_data["object"]["language"] = 'ak'
-    source_data["object"]["accessPermissions"] = ["DERIVABLE"]
+    source_data["object"]["accessPermissions"] = [types.SourcePermissions.DERIVABLE.value]
     resposne = check_post(SOURCE_GLOBAL_QUERY,source_data)
     resp_data = resposne["data"]["addSource"]["data"]["metaData"]
     assert resp_data["accessPermissions"] == \

--- a/app/test/test_gql_stop_words_generation.py
+++ b/app/test/test_gql_stop_words_generation.py
@@ -301,7 +301,7 @@ def get_job_status(job_id):
 
 #     table_name = add_dict_source()
 #     add_tw_dict(table_name)
-#     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['APIUser']['token']
+#     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['BcsDev']['token']
 
 #     var_gen = {
 #   "lang_code": "hi"
@@ -328,6 +328,7 @@ def get_job_status(job_id):
 #         status = job_response1['data']['status']
 #         if status == 'job finished':
 #             break
+#         log.info(job_response1)
 #         log.info("sleeping for a minute in SW generate test")
 #         time.sleep(60)
 #     assert job_response1['data']['status'] == 'job finished'

--- a/app/test/test_gql_translation_workflow.py
+++ b/app/test/test_gql_translation_workflow.py
@@ -2,6 +2,7 @@
 This is not part of the automated tests, and data added to DB by running this script will persist.
 This is to be used manually during develepment testing'''
 from app.test import gql_request
+from app.graphql_api import types
 import json
 from .test_gql_agmt_translation import assert_positive_get_tokens_gql
 from .test_translation_workflow import bible_books,ALIGNMENT_SRC,alignment_data,ALIGNMENT_TRG
@@ -37,7 +38,7 @@ src_var={
     "version": "XYZ",
     "revision": "1",
     "accessPermissions": [
-            "CONTENT","OPENACCESS"
+            types.SourcePermissions.CONTENT.value,types.SourcePermissions.OPENACCESS.value
         ],
     "year": 2020,
     "license": "CC-BY-SA",

--- a/app/test/test_gql_versions.py
+++ b/app/test/test_gql_versions.py
@@ -2,6 +2,7 @@
 from typing import Dict
 
 #pylint: disable=E0401
+from app.schema import schema_auth
 from .test_versions import assert_positive_get
 #pylint: disable=E0611
 #pylint: disable=R0914
@@ -10,7 +11,9 @@ from . import  check_skip_limit_gql, gql_request,assert_not_available_content_gq
 from .conftest import initial_test_users
 
 headers_auth = {"contentType": "application/json",
-                "accept": "application/json"}
+                "accept": "application/json",
+                "App":schema_auth.App.VACHANADMIN.value,
+                "Authorization": "Bearer "+initial_test_users["VachanAdmin"]["token"]}
 headers = {"contentType": "application/json", "accept": "application/json"}
 
 GLOBAL_VARIABLES = {
@@ -40,6 +43,7 @@ GLOBAL_QUERY = """
 def check_post(query, variables):
     """common for check post"""
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['APIUser']['token']
+    headers_auth['App'] = schema_auth.App.VACHANADMIN.value
     #without auth
     executed = gql_request(query=query,operation="mutation", variables=variables)
     assert "errors" in executed.keys()
@@ -209,6 +213,8 @@ QUERY_GET = """
 def test_get():
     '''Test get before adding data to table. Usually run on new test DB on local or github.
     If the testing is done on a DB that already has data(staging), the response wont be empty.'''
+    headers_auth['App'] = schema_auth.App.API.value
+    headers_auth['Authorization'] = "Bearer "+initial_test_users['APIUser']['token']
     executed =  gql_request(query=QUERY_GET,headers=headers_auth)
     if len(executed["data"]["versions"]) == 0:
         assert_not_available_content_gql(executed["data"]["versions"])
@@ -298,7 +304,8 @@ def test_get_after_adding_data():
     get_version_var = {
     "VAbb": "AAA"
     }
-
+    headers_auth['App'] = schema_auth.App.API.value
+    headers_auth['Authorization'] = "Bearer "+initial_test_users['APIUser']['token']
     executed_get = gql_request(query_get_version_added,variables=get_version_var,
     headers=headers_auth)
     assert isinstance(executed_get, Dict)
@@ -425,6 +432,8 @@ def test_get_after_adding_data():
     }
     }
     """
+    headers_auth['App'] = schema_auth.App.API.value
+    headers_auth['Authorization'] = "Bearer "+initial_test_users['APIUser']['token']
     executed5 = gql_request(query5,headers=headers_auth)
     assert isinstance(executed5, Dict)
     assert len(executed5["data"]["versions"]) == 1

--- a/app/test/test_source_get_sentence.py
+++ b/app/test/test_source_get_sentence.py
@@ -1,5 +1,6 @@
 '''Test cases for extract text related APIs'''
 from requests.api import head
+from app.schema import schemas, schema_auth
 from . import client
 from . import assert_input_validation_error, assert_not_available_content
 from . import check_default_get
@@ -12,7 +13,8 @@ UNIT_URL = 'v2/sources/'
 SENT_URL = UNIT_URL+ "get-sentence"
 headers = {"contentType": "application/json", "accept": "application/json"}
 headers_auth = {"contentType": "application/json",
-                "accept": "application/json"
+                "accept": "application/json",
+                "Authentication":"Bearer"+" "+initial_test_users['APIUser']['token']
             }
 
 def assert_positive_get(item):
@@ -49,6 +51,8 @@ commentary_data = [
 
 def create_sources():
     '''prior steps and post attempt, without checking the response'''
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['VachanAdmin']['token']
+    headers_auth["App"] = schema_auth.App.VACHAN.value
     version_data = {
         "versionAbbreviation": "TTT",
         "versionName": "test version for get sentence",
@@ -59,7 +63,8 @@ def create_sources():
         "language": "hi",
         "version": "TTT",
         "year": 2020,
-        "revision": 1
+        "revision": 1,
+        "accessPermissions":[schemas.SourcePermissions.CONTENT.value, schemas.SourcePermissions.OPENACCESS.value]
     }
     source = add_source(source_data)
     bible_name = source.json()['data']['sourceName']
@@ -71,7 +76,9 @@ def create_sources():
         "language": "en",
         "version": "TTT",
         "year": 2020,
-        "revision": 1
+        "revision": 1,
+        "accessPermissions":[schemas.SourcePermissions.CONTENT.value, schemas.SourcePermissions.OPENACCESS.value]
+
     }
     source = add_source(source_data)
     commentary_name = source.json()['data']['sourceName']
@@ -82,7 +89,6 @@ def create_sources():
 
 def test_get_poisitive():
 	'''normal tests for all possible get queries'''
-	headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['VachanAdmin']['token']
 	# Before adding data
 	resp = client.get(SENT_URL+"?source_name=hi_TTT_1_bible", headers= headers_auth)
 	assert resp.status_code == 404
@@ -90,6 +96,8 @@ def test_get_poisitive():
 	# Add data
 	bible_name, commentary_name = create_sources()
 
+	headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['BcsDev']['token']
+	headers_auth['App'] = schema_auth.App.API
 	check_default_get(SENT_URL, headers_auth, assert_positive_get)
 
 	# filtering with various params
@@ -163,6 +171,8 @@ def test_get_negatives():
 	'''error or not available cases'''
 	# Add data
 	bible_name, commentary_name = create_sources()
+	headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['BcsDev']['token']
+	headers_auth['App'] = schema_auth.App.API
 
 	for buk in ['mat','mrk','luk','jhn']:
 		resp = client.get(SENT_URL+'?source_name='+commentary_name+'&books='+buk, headers=headers_auth)

--- a/app/test/test_stop_words_generation.py
+++ b/app/test/test_stop_words_generation.py
@@ -2,7 +2,7 @@
 import json
 import time
 from app.main import log
-from app.schema import schema_auth
+from app.schema import schema_auth, schemas
 from . import client
 from . import check_default_get
 from . import assert_not_available_content
@@ -224,7 +224,8 @@ def add_bible_source():
     "revision": 1,
     "year": 2020,
     "license": "CC-BY-SA",
-    "metaData": {"owner": "someone", "access-key": "123xyz"}
+    "metaData": {"owner": "someone" },
+    "accessPermissions": [schemas.SourcePermissions.OPENACCESS, schemas.SourcePermissions.CONTENT]
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['VachanAdmin']['token']
     source = client.post('/v2/sources', headers=headers_auth, json=src_data)
@@ -239,7 +240,8 @@ def add_dict_source():
         "language": "hi",
         "version": "TW",
         "revision": 1,
-        "year": 2000
+        "year": 2000,
+        "accessPermissions": [schemas.SourcePermissions.OPENACCESS, schemas.SourcePermissions.CONTENT]
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['VachanAdmin']['token']
     source = client.post('/v2/sources', headers=headers_auth, json=source_data)
@@ -274,7 +276,7 @@ def test_generate_stopwords():
 
     table_name = add_dict_source()
     add_tw_dict(table_name)
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['APIUser']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['BcsDev']['token']
 
     response = client.post(GER_URL+'/generate?language_code=hi',headers=headers_auth)
     assert response.status_code == 201


### PR DESCRIPTION
fixes the issues in new auth logic which checks for access control for APIs like update-project, get-text-contents, generate-sw that operates on multiple resources and hence require multiple permmisons
- Updations in rules and API-permission map
- Changes in auth logic to just check for one permission(not list) in one call(router function)
- Changes in tests that were working before, even with incorrect values and started failing after the changes in auth logic