### PR TITLE
give suggested tokenization in /suggestions API

### DIFF
--- a/app/crud/nlp_crud.py
+++ b/app/crud/nlp_crud.py
@@ -747,12 +747,13 @@ def auto_translate_token_logic(db_,tokens, sent, source_lang, target_lang):
             if len(suggestions) > 0:
                 draft, meta = nlp_utils.replace_token(sent.sentence, offset,
                     suggestions[0], sent.draftMeta, "suggestion",draft=sent.draft)
-                sent.draft = draft
-                sent.draftMeta = meta
-            elif (sent.draft is None or sent.draft == ''):
-                sent.draft = sent.sentence
-                offset = [0,len(sent.sentence)]
-                sent.draftMeta = [[offset, offset, "untranslated"]]
+            else:
+                # splits the source sentence into tokens(in draftmeta)
+                # even if there is no transltion suggestion available.
+                draft, meta = nlp_utils.replace_token(sent.sentence, offset,
+                    token, sent.draftMeta, "untranslated",draft=sent.draft)
+            sent.draft = draft
+            sent.draftMeta = meta
 
 def auto_translate(db_, sentence_list, source_lang, target_lang, **kwargs):
     '''Attempts to tokenize the input sentence and replace each token with top suggestion.

--- a/app/test/test_translation_suggestions.py
+++ b/app/test/test_translation_suggestions.py
@@ -251,6 +251,11 @@ def test_learn_n_suggest():
     #with auth
     response = client.put(UNIT_URL+'/suggestions?source_language=en&target_language=ml',
         headers=headers_auth, json={"sentence_list":sentence_list})
+
+    # ensures that source is tokenized in draftmeta, even when there is no suggestion
+    assert len(response.json()[0]["draftMeta"]) > 7 
+    assert len([meta for meta in response.json()[0]["draftMeta"] if meta[2]=="untranslated"]) > 4
+    
     draft = client.put(UNIT_URL+'/draft?doc_type=text', headers=headers_auth, json=response.json())
     draft = draft.json()
     assert "ഒരു ടെസ്റ്റ് കേസ്." in draft


### PR DESCRIPTION
Fixes #381 

If the source sentence is 
```
"This is the day!"
```
After the `/v2/autographa/project/suggestions` and `/v2/translation/suggestions` the draft and draftmeta are like this
```
"draft": "ഇത് is the day!",
 "draftMeta": [
            [ [ 0, 4 ], [ 0, 3 ], "suggestion"],
            [ [ 4, 5 ], [ 3, 4 ], "untranslated" ],
            [ [ 5, 15], [ 4, 14 ], "untranslated" ],
            [ [15,16], [ 14, 15 ], "untranslated"]
]
```