### PR TITLE
Have better error reporting in media APIs

### DIFF
--- a/app/custom_exceptions.py
+++ b/app/custom_exceptions.py
@@ -20,6 +20,14 @@ class DatabaseException(Exception):
             self.detail = str(detail)
         self.status_code = 502
 
+class GitlabException(Exception):
+    '''Format for Gitlab error in media access APIs'''
+    def __init__(self, detail):
+        super().__init__()
+        self.name = "Gitlab Access Error"
+        self.detail = detail
+        self.status_code = 502
+
 class NotAvailableException(Exception):
     '''Format for not available Exception'''
     def __init__(self, detail: str):

--- a/app/routers/media_api.py
+++ b/app/routers/media_api.py
@@ -49,7 +49,8 @@ async def get_and_accesscheck_for_repo(repo, file_path, tag, permanent_link, db_
         raise
 
     if len(tables) == 0:
-        raise NotAvailableException("No sources available for the requested name or language")
+        raise NotAvailableException("No sources available for the requested repo, \
+accessible to the user")
     if tag is None:
         if not "defaultBranch" in tables[0].metaData:
             raise NotAvailableException("Default Branch is Not in source metadata")

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,3 +61,4 @@ Unidecode==1.2.0
 urllib3==1.26.6
 uvicorn==0.14.0
 wrapt==1.12.1
+beautifulsoup4==4.11.1


### PR DESCRIPTION
This PR is made in connection with the issue #389 

1. The first issue why the repo was not accessible was it was "internal". Changed it to public in gitlab. (Also raised an issue #390 )
2. The `"No sources available for the requested name or language"` error message was due to expired access-token, that filtered out the response items from get_sources. Updated the error message slighty to indicate it could be an access issue too.
3. The download API was returning the error HTML page from gitlab even when the stream was not available. Fixed it with a custom exception handling for Gitlab errors
