### PR TITLE
Feature/project books update upon csv upload

### DIFF
--- a/app/crud/projects_crud.py
+++ b/app/crud/projects_crud.py
@@ -48,7 +48,7 @@ def create_agmt_project(db_:Session, project, user_id=None):
     # db_.commit()
     return db_content
 
-book_pattern_in_surrogate_id = re.compile(r'^\w\w\w')
+book_pattern_in_surrogate_id = re.compile(r'^[\w\d]\w\w')
 def update_agmt_project_sentences(db_, project_obj, new_books, user_id):
     """bulk selected book update in update agmt project"""
     for sent in project_obj.sentenceList:

--- a/app/crud/projects_crud.py
+++ b/app/crud/projects_crud.py
@@ -2,6 +2,7 @@
 AgMT Project Management. The translation or NLP related functions of these
 projects are included in nlp_crud module'''
 
+import re
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
 
@@ -47,11 +48,16 @@ def create_agmt_project(db_:Session, project, user_id=None):
     # db_.commit()
     return db_content
 
-def update_agmt_project_sentences(db_, project_obj, user_id):
+book_pattern_in_surrogate_id = re.compile(r'^\w\w\w')
+def update_agmt_project_sentences(db_, project_obj, new_books, user_id):
     """bulk selected book update in update agmt project"""
     for sent in project_obj.sentenceList:
         norm_sent = utils.normalize_unicode(sent.sentence)
         offsets = [0, len(norm_sent)]
+        if re.search(book_pattern_in_surrogate_id, sent.surrogateId):
+            book_code =  re.search(book_pattern_in_surrogate_id, sent.surrogateId).group(0).lower()
+            if book_code not in new_books and book_code in utils.BOOK_CODES:
+                new_books.append(book_code)
         draft_row = db_models.TranslationDraft(
             project_id=project_obj.projectId,
             sentenceId=sent.sentenceId,
@@ -100,8 +106,7 @@ def update_agmt_project(db_:Session, project_obj, user_id=None):
     if project_obj.selectedBooks:
         new_books += project_obj.selectedBooks.books
     if project_obj.sentenceList:
-        update_agmt_project_sentences(db_, project_obj, user_id)
-
+        update_agmt_project_sentences(db_, project_obj, new_books, user_id)
     if project_obj.uploadedUSFMs:
         #uploaded usfm book add to project
         update_agmt_project_uploaded_book(db_,project_obj,new_books,user_id)

--- a/app/crud/utils.py
+++ b/app/crud/utils.py
@@ -89,6 +89,9 @@ books = {
 67: {"book_code": "rev", "book_name": "revelation"}
 }
 
+BOOK_CODES = [ books[key]['book_code'] for key in books]
+
+
 def book_code(book_num):
     '''get the book for for the input bokk number'''
     if book_num in books:

--- a/app/crud/utils.py
+++ b/app/crud/utils.py
@@ -89,7 +89,7 @@ books = {
 67: {"book_code": "rev", "book_name": "revelation"}
 }
 
-BOOK_CODES = [ books[key]['book_code'] for key in books]
+BOOK_CODES = [ val['book_code'] for key, val in books.items()]
 
 
 def book_code(book_num):


### PR DESCRIPTION
fixes #393 
When source sentences are upload as `sentenceList` (instead of USFM or selecting from DB itself), now the server code checks if `surrogateId` of sentences starts with book code, thus identify the books and add the information to the project metadata.