### PR TITLE
Add 'editable' as a permission on sources

### DIFF
--- a/app/auth/access_rules.json
+++ b/app/auth/access_rules.json
@@ -19,6 +19,10 @@
         "refer-for-translation": ["SuperAdmin", "AgAdmin", "AgUser"],
         "translate":["SuperAdmin", "AgAdmin", "AgUser"]
     },
+    "editable":{
+        "create": ["SuperAdmin", "VachanAdmin", "AgAdmin", "AgUser"],
+        "edit": ["SuperAdmin", "VachanAdmin", "AgAdmin", "AgUser"]
+    },
     "publishable":{
         "read-via-api":["registeredUser"],
         "view-on-web":["noAuthRequired"],

--- a/app/schema/schemas.py
+++ b/app/schema/schemas.py
@@ -137,6 +137,7 @@ class SourcePermissions(str, Enum):
     DOWNLOADABLE = "downloadable"
     DERIVABLE = "derivable"
     RESEARCHUSE = "research-use"
+    EDITABLE = "editable"
 
 LicenseCodePattern =constr(regex=r"^[a-zA-Z0-9\.\_\-]+$")
 


### PR DESCRIPTION
**Requirement** : As per the existing rules a source content can only be edited by either admins or the person who created it.
For the sign language UI project, we create a dictionary source. The app users(AgUser) who work on the project should be able to define signs via adding them as dictionary entries to the source dictionary created for this purpose. A different user of the app should then be allowed to edit these entries adding more details to them.

By this change, adding a source permission called "editable". If we add this to the source(as its permission, just like "downloadble", "open-access" etc), then AgUsers are also allowed to create entries and edit them.