### PR TITLE
update SSL certificate renewal instruction

### DIFF
--- a/docs/docker-guide.md
+++ b/docs/docker-guide.md
@@ -99,6 +99,8 @@ To re-create SSL certificates, follow instructions [here](https://mindsers.blog/
 docker-compose -f production.yml run --rm certbot renew
 ```
 
+After this make sure the certificate folder in the app root has access permission. or change it with `sudo chmod -R 777 certbot/`
+
 ### To start the app
 
 ```


### PR DESCRIPTION
The SSL certificates had to be renewed recently. It was done before the last date. But app started showing "no certificate" warning on the date of expiry in spite of the update.

The issue was, after the update the folder with the certificate became accessible only with sudo and was not accessible to docker instances. We need to make sure the folder permissions are changed after the certificate renewal