### PR TITLE
bugfix/Kratos DB volume

### DIFF
--- a/docker/Kratos_config/database.yml
+++ b/docker/Kratos_config/database.yml
@@ -31,6 +31,9 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=md5
     networks:
       - vachan-auth-net
+    volumes: 
+      - kratos-postgres-vol:/var/lib/postgresql/data
+
 
   # offen backup
   offen-backup_kratos_daily: &backup_service
@@ -45,7 +48,7 @@ services:
     depends_on:
       - kratos-migrate
     volumes:
-      - kratos-sqlite:/docker_kratos-sqlite:ro
+      - kratos-postgres-vol:/docker_kratos-sqlite:ro
       # - /var/run/docker.sock:/var/run/docker.sock:ro
       - /var/lib/backups:/archive
     networks:
@@ -64,7 +67,7 @@ services:
     depends_on:
       - kratos-migrate
     volumes:
-      - kratos-sqlite:/docker_kratos-sqlite:ro
+      - kratos-postgres-vol:/docker_kratos-sqlite:ro
       # - /var/run/docker.sock:/var/run/docker.sock:ro
       - /var/lib/backups:/archive
     networks:
@@ -83,7 +86,7 @@ services:
     depends_on:
       - kratos-migrate
     volumes:
-      - kratos-sqlite:/docker_kratos-sqlite:ro
+      - kratos-postgres-vol:/docker_kratos-sqlite:ro
       # - /var/run/docker.sock:/var/run/docker.sock:ro
       - /var/lib/backups:/archive
     networks:
@@ -102,7 +105,7 @@ services:
     depends_on:
       - kratos-migrate
     volumes:
-      - kratos-sqlite:/docker_kratos-sqlite:ro
+      - kratos-postgres-vol:/docker_kratos-sqlite:ro
       # - /var/run/docker.sock:/var/run/docker.sock:ro
       - /var/lib/backups:/archive
     networks:
@@ -112,3 +115,4 @@ networks:
   vachan-auth-net:
 volumes:
   kratos-sqlite:
+  kratos-postgres-vol:

--- a/docker/Kratos_config/database.yml
+++ b/docker/Kratos_config/database.yml
@@ -42,13 +42,13 @@ services:
     environment: &backup_environment #Daily 00 : 00
       BACKUP_CRON_EXPRESSION: "0 0 * * *"
       BACKUP_FILENAME: backup-kratos-daily-%Y-%m-%dT%H-%M-%S.tar.gz
-      BACKUP_SOURCES: /docker_kratos-sqlite
+      BACKUP_SOURCES: /docker_kratos-postgres
       BACKUP_PRUNING_PREFIX: backup-kratos-daily-
       BACKUP_RETENTION_DAYS: 5
     depends_on:
       - kratos-migrate
     volumes:
-      - kratos-postgres-vol:/docker_kratos-sqlite:ro
+      - kratos-postgres-vol:/docker_kratos-postgres:ro
       # - /var/run/docker.sock:/var/run/docker.sock:ro
       - /var/lib/backups:/archive
     networks:
@@ -61,13 +61,13 @@ services:
       # SAT 00 : 00
       BACKUP_CRON_EXPRESSION: "0 0 * * 6"
       BACKUP_FILENAME: backup-kratos-week-%Y-%m-%dT%H-%M-%S.tar.gz
-      BACKUP_SOURCES: /docker_kratos-sqlite
+      BACKUP_SOURCES: /docker_kratos-postgres
       BACKUP_PRUNING_PREFIX: backup-kratos-week-
       BACKUP_RETENTION_DAYS: 49
     depends_on:
       - kratos-migrate
     volumes:
-      - kratos-postgres-vol:/docker_kratos-sqlite:ro
+      - kratos-postgres-vol:/docker_kratos-postgres:ro
       # - /var/run/docker.sock:/var/run/docker.sock:ro
       - /var/lib/backups:/archive
     networks:
@@ -80,13 +80,13 @@ services:
       # monthly on 28  00 : 00
       BACKUP_CRON_EXPRESSION: "0 0 28 * *"
       BACKUP_FILENAME: backup-kratos-month-%Y-%m-%dT%H-%M-%S.tar.gz
-      BACKUP_SOURCES: /docker_kratos-sqlite
+      BACKUP_SOURCES: /docker_kratos-postgres
       BACKUP_PRUNING_PREFIX: backup-kratos-month-
       BACKUP_RETENTION_DAYS: 365
     depends_on:
       - kratos-migrate
     volumes:
-      - kratos-postgres-vol:/docker_kratos-sqlite:ro
+      - kratos-postgres-vol:/docker_kratos-postgres:ro
       # - /var/run/docker.sock:/var/run/docker.sock:ro
       - /var/lib/backups:/archive
     networks:
@@ -99,13 +99,13 @@ services:
       # yearly DEC 31 day 00 : 00
       BACKUP_CRON_EXPRESSION: "0 0 31 12 *"
       BACKUP_FILENAME: backup-kratos-year-%Y-%m-%dT%H-%M-%S.tar.gz
-      BACKUP_SOURCES: /docker_kratos-sqlite
+      BACKUP_SOURCES: /docker_kratos-postgres
       BACKUP_PRUNING_PREFIX: backup-kratos-year-
       BACKUP_RETENTION_DAYS: 2555
     depends_on:
       - kratos-migrate
     volumes:
-      - kratos-postgres-vol:/docker_kratos-sqlite:ro
+      - kratos-postgres-vol:/docker_kratos-postgres:ro
       # - /var/run/docker.sock:/var/run/docker.sock:ro
       - /var/lib/backups:/archive
     networks:

--- a/docker/Kratos_config/quickstart.yml
+++ b/docker/Kratos_config/quickstart.yml
@@ -72,9 +72,12 @@ services:
       - POSTGRES_DB=kratos
     networks:
       - intranet
+    volumes: 
+      - kratos-postgres-vol:/var/lib/postgresql/data
 
 networks:
   intranet:
 
 volumes:
   kratos-sqlite:
+  kratos-postgres-vol:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
     networks:
       - my-network
+    volumes: 
+      - kratos-postgres-vol:/var/lib/postgresql/data
 
  kratos:
     image: oryd/kratos:v0.7.0-alpha.1
@@ -181,3 +183,4 @@ volumes:
   kratos-sqlite:
   redis-data:
   redisinsight:
+  kratos-postgres-vol:

--- a/docker/run-test-dependencies.yml
+++ b/docker/run-test-dependencies.yml
@@ -28,6 +28,8 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
     networks:
       - my-test-network
+    volumes: 
+      - kratos-postgres-vol:/var/lib/postgresql/data
 
  kratos:
   image: oryd/kratos:v0.7.0-alpha.1
@@ -93,3 +95,4 @@ volumes:
   logs-test-vol:
   kratos-sqlite-test:
   redis-data:
+  kratos-postgres-vol:


### PR DESCRIPTION
fixes #431 
use volumes for Kratos postgres DB and point the offen backup to this instead of sqlite.