### PR TITLE
change the data path in Kratos DB volume

### DIFF
--- a/docker/Kratos_config/database.yml
+++ b/docker/Kratos_config/database.yml
@@ -33,6 +33,7 @@ services:
       - vachan-auth-net
     volumes: 
       - kratos-postgres-vol:/data
+    restart: always
 
 
   # offen backup
@@ -46,7 +47,7 @@ services:
       BACKUP_PRUNING_PREFIX: backup-kratos-daily-
       BACKUP_RETENTION_DAYS: 5
     depends_on:
-      - kratos-migrate
+      - postgresd
     volumes:
       - kratos-postgres-vol:/docker_kratos-postgres:ro
       # - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -65,7 +66,7 @@ services:
       BACKUP_PRUNING_PREFIX: backup-kratos-week-
       BACKUP_RETENTION_DAYS: 49
     depends_on:
-      - kratos-migrate
+      - postgresd
     volumes:
       - kratos-postgres-vol:/docker_kratos-postgres:ro
       # - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -84,7 +85,7 @@ services:
       BACKUP_PRUNING_PREFIX: backup-kratos-month-
       BACKUP_RETENTION_DAYS: 365
     depends_on:
-      - kratos-migrate
+      - postgresd
     volumes:
       - kratos-postgres-vol:/docker_kratos-postgres:ro
       # - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -103,7 +104,7 @@ services:
       BACKUP_PRUNING_PREFIX: backup-kratos-year-
       BACKUP_RETENTION_DAYS: 2555
     depends_on:
-      - kratos-migrate
+      - postgresd
     volumes:
       - kratos-postgres-vol:/docker_kratos-postgres:ro
       # - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/docker/Kratos_config/database.yml
+++ b/docker/Kratos_config/database.yml
@@ -32,7 +32,7 @@ services:
     networks:
       - vachan-auth-net
     volumes: 
-      - kratos-postgres-vol:/var/lib/postgresql/data
+      - kratos-postgres-vol:/data
 
 
   # offen backup

--- a/docker/Kratos_config/database.yml
+++ b/docker/Kratos_config/database.yml
@@ -31,8 +31,13 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=md5
     networks:
       - vachan-auth-net
-    volumes: 
-      - kratos-postgres-vol:/data
+    volumes:
+      - type: volume
+        source: kratos-postgres-vol
+        target: /var/lib/postgresql/data
+        read_only: false
+    # volumes: 
+    #   - kratos-postgres-vol:/data
     restart: always
 
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,8 +28,13 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
     networks:
       - my-network
-    volumes: 
-      - kratos-postgres-vol:/data
+    volumes:
+      - type: volume
+        source: kratos-postgres-vol
+        target: /var/lib/postgresql/data
+        read_only: false
+    # volumes: 
+    #   - kratos-postgres-vol:/data
     restart: always
 
  kratos:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     networks:
       - my-network
     volumes: 
-      - kratos-postgres-vol:/var/lib/postgresql/data
+      - kratos-postgres-vol:/data
 
  kratos:
     image: oryd/kratos:v0.7.0-alpha.1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - my-network
     volumes: 
       - kratos-postgres-vol:/data
+    restart: always
 
  kratos:
     image: oryd/kratos:v0.7.0-alpha.1

--- a/docker/run-test-dependencies.yml
+++ b/docker/run-test-dependencies.yml
@@ -28,8 +28,13 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
     networks:
       - my-test-network
-    volumes: 
-      - kratos-postgres-vol:/data
+    volumes:
+      - type: volume
+        source: kratos-postgres-vol
+        target: /var/lib/postgresql/data
+        read_only: false
+    # volumes: 
+    #   - kratos-postgres-vol:/data
     restart: always
 
  kratos:

--- a/docker/run-test-dependencies.yml
+++ b/docker/run-test-dependencies.yml
@@ -29,7 +29,7 @@ services:
     networks:
       - my-test-network
     volumes: 
-      - kratos-postgres-vol:/var/lib/postgresql/data
+      - kratos-postgres-vol:/data
 
  kratos:
   image: oryd/kratos:v0.7.0-alpha.1

--- a/docker/run-test-dependencies.yml
+++ b/docker/run-test-dependencies.yml
@@ -30,6 +30,7 @@ services:
       - my-test-network
     volumes: 
       - kratos-postgres-vol:/data
+    restart: always
 
  kratos:
   image: oryd/kratos:v0.7.0-alpha.1


### PR DESCRIPTION
Change the path of data directory in postgres 9 container used for Kratos DB, to ensure the backup is taken properly.

fixes #431 
fixes #436 