### PR TITLE
Bugfix/initialise as empty drafts

### DIFF
--- a/app/crud/nlp_crud.py
+++ b/app/crud/nlp_crud.py
@@ -757,7 +757,7 @@ def auto_translate_token_logic(db_,tokens, sent, source_lang, target_lang):
                 # splits the source sentence into tokens(in draftmeta)
                 # even if there is no transltion suggestion available.
                 draft, meta = nlp_utils.replace_token(sent.sentence, offset,
-                    token, sent.draftMeta, "untranslated",draft=sent.draft)
+                    "", sent.draftMeta, "untranslated",draft=sent.draft)
             sent.draft = draft
             sent.draftMeta = meta
 

--- a/app/crud/nlp_tokenization.py
+++ b/app/crud/nlp_tokenization.py
@@ -226,44 +226,76 @@ def tokenize(db_:Session, src_lang, sent_list, #pylint: disable=too-many-locals
 
     return unique_tokens
 
-# def replace_token_check_begin_end(token_offset,tkn_offset
-#                 ,updated_draft,translation,trans_offset,updated_meta,source,tag):
-#     """check the begining matches or not"""
-#     # ,*args
-#     # updated_meta = args[0]
-#     # source = args[1]
-#     # tag = args[2]
-#     trans_length = len(translation)
-#     translation_offset = [None, None]
-#     offset_diff = 0
-#     if token_offset[0] == tkn_offset[0]: #begining is same
-#         translation_offset[0] = trans_offset[0]
-#         updated_draft += translation
-#     elif token_offset[0] > tkn_offset[0]: # begins within this segment
-#         updated_draft += source[tkn_offset[0]: token_offset[0]]
-#         new_seg_len = token_offset[0] - tkn_offset[0]
-#         updated_meta.append(((tkn_offset[0], token_offset[0]),
-#             (trans_offset[0], trans_offset[0]+new_seg_len),"untranslated"))
-#         translation_offset[0] = trans_offset[0]+new_seg_len
-#         updated_draft += translation
-#     else: # begins before this segment
-#         pass
-#     if token_offset[1] == tkn_offset[1]: # ending is the same
-#         translation_offset[1] = translation_offset[0]+trans_length
-#         updated_meta.append((token_offset, translation_offset, tag))
-#         offset_diff = translation_offset[1] - trans_offset[1]
-#     elif token_offset[1] < tkn_offset[1]: # ends within this segment
-#         trailing_seg = source[token_offset[1]: tkn_offset[1]]
-#         translation_offset[1] = translation_offset[0]+trans_length
-#         updated_meta.append((token_offset, translation_offset, tag))
-#         updated_draft += trailing_seg
-#         updated_meta.append(((token_offset[1], tkn_offset[1]),
-#             (translation_offset[1],translation_offset[1]+len(trailing_seg)),
-#             "untranslated"))
-#         offset_diff = translation_offset[1]+len(trailing_seg) - trans_offset[1]
-#     else: # ends after this segment
-#         pass
-#     return offset_diff,updated_draft,updated_meta
+def replace_token_inside(token_offset, translation, tag, **kwargs):
+    '''Replace token when our area of interest overlaps with this segment'''
+    src_seg_offset = kwargs.get("src_seg_offset")
+    updated_draft = kwargs.get("updated_draft")
+    updated_meta = kwargs.get("updated_meta")
+    translation_offset = kwargs.get("translation_offset")
+    if token_offset[0] == src_seg_offset[0]: #begining is same
+        if (updated_draft != "") and (not updated_draft.endswith(" "))\
+        and (translation != ""):
+            # to have a space b/w existing words and new translation
+            updated_draft += " "
+            draft_end = len(updated_draft)
+            updated_meta.append([[src_seg_offset[0], src_seg_offset[0]],
+                [draft_end-1,draft_end],"untranslated"])
+        translation_offset[0] = len(updated_draft)
+        updated_draft += translation
+    elif token_offset[0] > src_seg_offset[0]: # begins within this segment
+        draft_end = len(updated_draft)
+        updated_meta.append([[src_seg_offset[0], token_offset[0]],
+            [draft_end, draft_end],"untranslated"])
+        if (updated_draft != "") and (not updated_draft.endswith(" "))\
+        and (translation != ""):
+            # to have a space b/w existing words and new translation
+            updated_draft += " "
+            updated_meta.append([[token_offset[0], token_offset[0]],
+                [draft_end,draft_end+1],"untranslated"])
+        translation_offset[0] = len(updated_draft)
+        updated_draft += translation
+    else: # begins before this segment
+        pass
+    if token_offset[1] == src_seg_offset[1]: # ending is the same
+        translation_offset[1] = len(updated_draft)
+        updated_meta.append((token_offset, translation_offset, tag))
+    elif token_offset[1] < src_seg_offset[1]: # ends within this segment
+        translation_offset[1] = len(updated_draft)
+        updated_meta.append((token_offset, translation_offset, tag))
+        updated_meta.append(((token_offset[1], src_seg_offset[1]),
+            (translation_offset[1],translation_offset[1]),
+            "untranslated"))
+    else: # ends after this segment
+        pass
+    return updated_draft, updated_meta, translation_offset
+
+
+def replace_token_outside(token_offset, draft, **kwargs):
+    '''Replace token when our area of interest doesn't overlap with this segment'''
+    src_seg_offset = kwargs.get("src_seg_offset")
+    draft_seg_offset = kwargs.get("draft_seg_offset")
+    status = kwargs.get("status")
+    updated_draft = kwargs.get("updated_draft")
+    updated_meta = kwargs.get("updated_meta")
+    meta = kwargs.get("meta")
+    if src_seg_offset[1] < token_offset[1]: # our area of interest come after this segment
+        draft_end = len(updated_draft)
+        updated_draft += draft[draft_seg_offset[0]: draft_seg_offset[1]]
+        updated_meta.append(meta)
+    else: # our area of interest was before this segment
+        draft_end = len(updated_draft)
+        offset_diff = draft_end - draft_seg_offset[0]
+        this_draft_seg = draft[draft_seg_offset[0]: draft_seg_offset[1]]
+        if updated_draft.endswith(" ") or this_draft_seg.startswith(" "):
+            updated_draft += this_draft_seg
+        elif this_draft_seg != "":
+            updated_draft += " "+this_draft_seg
+            updated_meta.append([[src_seg_offset[0], src_seg_offset[0]],
+                [draft_end, draft_end+1], "untranslated"])
+            offset_diff += 1
+        updated_meta.append([src_seg_offset,
+            [draft_seg_offset[0]+offset_diff, draft_seg_offset[1]+offset_diff], status])
+    return updated_draft, updated_meta
 
 def replace_token(source, token_offset, translation,draft_meta, tag="confirmed",#pylint: disable=too-many-locals
     **kwargs):
@@ -272,8 +304,6 @@ def replace_token(source, token_offset, translation,draft_meta, tag="confirmed",
     Alignment: draftMeta for words in source or draft that are not aligned
         for source word s1-s5: [[1,5],[0,0], "untranslated"]
         for draft word d10-d17: [[8,8],[10,17, "untranslated"]'''
-    if not draft_meta:
-        draft_meta=[]
     draft= kwargs.get("draft","")
     updated_meta = []
     updated_draft = ""
@@ -289,57 +319,25 @@ def replace_token(source, token_offset, translation,draft_meta, tag="confirmed",
         intersection = set(range(token_offset[0],token_offset[1])).intersection(
             range(src_seg_offset[0],src_seg_offset[1]))
         if len(intersection) > 0: # our area of interest overlaps with this segment
-            if token_offset[0] == src_seg_offset[0]: #begining is same
-                if (updated_draft != "") and (not updated_draft.endswith(" "))\
-                and (translation != ""):
-                    # to have a space b/w existing words and new translation
-                    updated_draft += " "
-                    draft_end = len(updated_draft)
-                    updated_meta.append([[src_seg_offset[0], src_seg_offset[0]],
-                        [draft_end-1,draft_end],"untranslated"])
-                translation_offset[0] = len(updated_draft)
-                updated_draft += translation
-            elif token_offset[0] > src_seg_offset[0]: # begins within this segment
-                draft_end = len(updated_draft)
-                updated_meta.append([[src_seg_offset[0], token_offset[0]],
-                    [draft_end, draft_end],"untranslated"])
-                if (updated_draft != "") and (not updated_draft.endswith(" "))\
-                and (translation != ""):
-                    # to have a space b/w existing words and new translation
-                    updated_draft += " "
-                    updated_meta.append([[token_offset[0], token_offset[0]],
-                        [draft_end,draft_end+1],"untranslated"])
-                translation_offset[0] = len(updated_draft)
-                updated_draft += translation
-            else: # begins before this segment
-                pass
-            if token_offset[1] == src_seg_offset[1]: # ending is the same
-                translation_offset[1] = len(updated_draft)
-                updated_meta.append((token_offset, translation_offset, tag))
-            elif token_offset[1] < src_seg_offset[1]: # ends within this segment
-                translation_offset[1] = len(updated_draft)
-                updated_meta.append((token_offset, translation_offset, tag))
-                updated_meta.append(((token_offset[1], src_seg_offset[1]),
-                    (translation_offset[1],translation_offset[1]),
-                    "untranslated"))
-            else: # ends after this segment
-                pass
-
-        elif src_seg_offset[1] < token_offset[1]: # our area of interest come after this segment
-            draft_end = len(updated_draft)
-            updated_draft += draft[draft_seg_offset[0]: draft_seg_offset[1]]
-            updated_meta.append(meta)
-        else: # our area of interest was before this segment
-            draft_end = len(updated_draft)
-            offset_diff = draft_end - draft_seg_offset[0]
-            this_draft_seg = draft[draft_seg_offset[0]: draft_seg_offset[1]]
-            if updated_draft.endswith(" ") or this_draft_seg.startswith(" "):
-                updated_draft += this_draft_seg 
-            elif this_draft_seg != "":
-                updated_draft += " "+this_draft_seg
-                updated_meta.append([[src_seg_offset[0], src_seg_offset[0]],
-                    [draft_end, draft_end+1], "untranslated"])
-                offset_diff += 1
-            updated_meta.append([src_seg_offset,
-                [draft_seg_offset[0]+offset_diff, draft_seg_offset[1]+offset_diff], status])
+            updated_draft, updated_meta, translation_offset = replace_token_inside(
+                token_offset=token_offset,
+                translation=translation,
+                tag=tag,
+                src_seg_offset=src_seg_offset,
+                draft_seg_offset=draft_seg_offset,
+                status=status,
+                updated_draft=updated_draft,
+                updated_meta=updated_meta,
+                translation_offset=translation_offset
+                )
+        else:
+            updated_draft, updated_meta = replace_token_outside(token_offset=token_offset,
+                draft=draft,
+                src_seg_offset=src_seg_offset,
+                draft_seg_offset=draft_seg_offset,
+                status=status,
+                updated_draft=updated_draft,
+                updated_meta=updated_meta,
+                meta=meta
+                )
     return updated_draft, updated_meta

--- a/app/crud/nlp_tokenization.py
+++ b/app/crud/nlp_tokenization.py
@@ -203,7 +203,6 @@ def tokenize(db_:Session, src_lang, sent_list, #pylint: disable=too-many-locals
         if "draftMeta" in sent:
             for meta in sent['draftMeta']:
                 if meta[2] == "confirmed":
-                    print("Meta with confirmed", meta)
                     seg = sent['sentence'][prev_index:meta[0][0]]
                     if len(seg) > 0:
                         segments.append(seg)
@@ -277,8 +276,8 @@ def replace_token(source, token_offset, translation,draft_meta, tag="confirmed",
     trans_length = len(translation)
     translation_offset = [None, None]
     if draft_meta is None or len(draft_meta) == 0:
-        draft = source
-        draft_meta = [((0,len(source)), (0,len(source)), "untranslated")]
+        draft = ""
+        draft_meta = [[[0,len(source)], [0,0], "untranslated"]]
     for meta in draft_meta:
         tkn_offset = meta[0]
         trans_offset = meta[1]
@@ -295,8 +294,9 @@ def replace_token(source, token_offset, translation,draft_meta, tag="confirmed",
                 translation_offset[0] = trans_offset[0]
                 updated_draft += translation
             elif token_offset[0] > tkn_offset[0]: # begins within this segment
-                updated_draft += source[tkn_offset[0]: token_offset[0]]
-                new_seg_len = token_offset[0] - tkn_offset[0]
+                # updated_draft += source[tkn_offset[0]: token_offset[0]]
+                # new_seg_len = token_offset[0] - tkn_offset[0]
+                new_seg_len = 0
                 updated_meta.append(((tkn_offset[0], token_offset[0]),
                     (trans_offset[0], trans_offset[0]+new_seg_len),"untranslated"))
                 translation_offset[0] = trans_offset[0]+new_seg_len
@@ -308,14 +308,14 @@ def replace_token(source, token_offset, translation,draft_meta, tag="confirmed",
                 updated_meta.append((token_offset, translation_offset, tag))
                 offset_diff = translation_offset[1] - trans_offset[1]
             elif token_offset[1] < tkn_offset[1]: # ends within this segment
-                trailing_seg = source[token_offset[1]: tkn_offset[1]]
+                # trailing_seg = source[token_offset[1]: tkn_offset[1]]
                 translation_offset[1] = translation_offset[0]+trans_length
                 updated_meta.append((token_offset, translation_offset, tag))
-                updated_draft += trailing_seg
+                # updated_draft += trailing_seg
                 updated_meta.append(((token_offset[1], tkn_offset[1]),
-                    (translation_offset[1],translation_offset[1]+len(trailing_seg)),
+                    (translation_offset[1],translation_offset[1]),
                     "untranslated"))
-                offset_diff = translation_offset[1]+len(trailing_seg) - trans_offset[1]
+                offset_diff = translation_offset[1] - trans_offset[1]
             else: # ends after this segment
                 pass
 

--- a/app/test/test_agmt_translation2.py
+++ b/app/test/test_agmt_translation2.py
@@ -256,7 +256,10 @@ def test_empty_draft_initalization():
     for meta in resp.json()[0]['draftMeta']:
         if meta[0] == [5,11] and meta[2] == "suggestion":
             found_jungle_meta = True
-            assert meta[1] == [resp.json()[0]['draft'].index("കാട്"), len("കാട്")]
+            print("draft:", resp.json()[0]['draft'])
+            print("draft.index('കാട്'')",resp.json()[0]['draft'].index("കാട്"))
+            trans_index = resp.json()[0]['draft'].index("കാട്")
+            assert meta[1][0] == trans_index
         elif meta[2] == "untranslated":
             found_untranslated = True
     assert found_jungle_meta

--- a/app/test/test_generic_translation.py
+++ b/app/test/test_generic_translation.py
@@ -263,7 +263,18 @@ def test_token_translate():
     new_return_sent = response.json()['data'][0]
     assert "Jesus Christ" in new_return_sent['draft']
     # combined two segments to one
-    assert len(new_return_sent['draftMeta']) == len(return_sent['draftMeta']) -1
+    found_combined = False
+    found_seperate = False
+    for meta in new_return_sent['draftMeta']:
+        match meta[0]:
+            case [31, 35]:
+                found_seperate = True
+            case [36,40]:
+                found_seperate = True
+            case [31,40]:
+                found_combined = True
+    assert found_combined
+    assert not found_seperate
 
 def test_draft_generation():
     '''tests conversion of sentence list to differnt draft formats'''

--- a/app/test/test_gql_generic_translation.py
+++ b/app/test/test_gql_generic_translation.py
@@ -341,7 +341,19 @@ def test_token_translate():
     new_return_sent = executed3["data"]["translateToken"][0]
     assert "Jesus Christ" in new_return_sent['draft']
     # combined two segments to one
-    assert len(new_return_sent['draftMeta']) == len(return_sent['draftMeta']) -2
+    found_combined = False
+    found_seperate = False
+    for meta in new_return_sent['draftMeta']:
+        match meta[0]:
+            case [31, 35]:
+                found_seperate = True
+            case [36,40]:
+                found_seperate = True
+            case [31,40]:
+                found_combined = True
+    assert found_combined
+    assert not found_seperate
+
 
 def test_draft_generation():
     '''tests conversion of sentence list to differnt draft formats'''

--- a/app/test/test_gql_translation_suggestion.py
+++ b/app/test/test_gql_translation_suggestion.py
@@ -337,4 +337,4 @@ $punctuations:[String],$stopwords:Stopwords){
     assert "ഒരു ടെസ്റ്റ് കേസ്." in draft["data"]["convertToText"]
     assert "ടെസ്റ്റ് കേസ് ടെസ്റ്റ് ചെയ്തു" in draft["data"]["convertToText"] or "ടെസ്റ്റ് കേസ് ടെസ്റ്റഡ്" in draft["data"]["convertToText"]
     assert "ടെവെലപ്പര്‍" in draft["data"]["convertToText"]
-    assert "ഇത് ആണ്  sad story of a poor ടെസ്റ്റ് " in draft["data"]["convertToText"]
+    assert "ഇത് ആണ് ടെസ്റ്റ്" in draft["data"]["convertToText"]

--- a/app/test/test_translation_suggestions.py
+++ b/app/test/test_translation_suggestions.py
@@ -261,7 +261,7 @@ def test_learn_n_suggest():
     assert "ഒരു ടെസ്റ്റ് കേസ്." in draft
     assert "ടെസ്റ്റ് കേസ് ടെസ്റ്റ് ചെയ്തു" in draft or "ടെസ്റ്റ് കേസ് ടെസ്റ്റഡ്" in draft
     assert "ടെവെലപ്പര്‍" in draft
-    assert "ഇത് ആണ്  sad story of a poor ടെസ്റ്റ് " in draft
+    assert "ഇത് ആണ് ടെസ്റ്റ്" in draft
 
 def test_bug_fix():
     '''testing bug fix for issue #412'''


### PR DESCRIPTION
Fix for #452 .
Previous change where we are not initializing draft field of projects with source text, wasn't enough. In the logic of making suggested translation, we were filling in source snippets where ever there was no suggestion to provide. This logic has been re-written considerably to ensure proper working with the new format of draft and draft_meta.

Also, now we follow the practice of including an entry in draftMeta for all parts of the source and draft sentences, even if they are not aligned to the opposite side. To mark such cases where we have words on one side but not corresponding alignments on the other, we now align it to an empty snippet (eg.: [0,0] or [8,8] which are segments of length zero) 