### PR TITLE
Feature/vachan demos service

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -27,7 +27,7 @@ if os.environ.get("VACHAN_TEST_MODE", "False") != 'True':
 
     create_super_user()
 
-app = FastAPI(title="Vachan-API", version="2.0.0-beta.5",
+app = FastAPI(title="Vachan-API", version="2.0.0-beta.6",
     description="The server application that provides APIs to interact \
 with the underlying Databases and modules in Vachan-Engine.")
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -128,7 +128,7 @@ services:
      - my-network
 
  vachan-demos:
-    image: kavitha3797/vachan-demos:2.0.0-alpha.2
+    image: kavitha3797/vachan-demos:latest
     expose:
       - 8002
     command: uvicorn main:app --host 0.0.0.0 --port 8002

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -127,6 +127,20 @@ services:
     networks:
      - my-network
 
+ vachan-demos:
+    image: kavitha3797/vachan-demos:2.0.0-alpha.2
+    expose:
+      - 8002
+    command: uvicorn main:app --host 0.0.0.0 --port 8002
+    restart: always
+    environment:
+     - VACHAN_DOMAIN=${VACHAN_DOMAIN:-api.vachanengine.org}
+     - VACHAN_LOGGING_LEVEL=INFO
+    volumes:
+     - logs-vol:/app/logs
+    networks:
+     - my-network
+
  # Web Server
  web-server:
     image: nginx:latest

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -10,6 +10,14 @@ server {
 		
         try_files $uri $uri/ =404;
     }
+    location /v2/demos/ {
+		# Important, make sure you always remove the trailing slash
+        proxy_pass http://vachan-demos:8002;    
+        proxy_set_header      X-Real-IP $remote_addr;
+        proxy_set_header      X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header      Host $http_host;
+        proxy_set_header X-Forwarded-Proto $scheme;        
+    }    
 
     location / {
 		# Important, make sure you always remove the trailing slash

--- a/docker/nginx/prod/app.conf.template
+++ b/docker/nginx/prod/app.conf.template
@@ -35,7 +35,11 @@ server {
 
     ssl_certificate /etc/nginx/ssl/live/${VACHAN_DOMAIN}/fullchain.pem;
     ssl_certificate_key /etc/nginx/ssl/live/${VACHAN_DOMAIN}/privkey.pem;
-    
+ 
+    location /v2/demos/ {
+        proxy_pass http://vachan-demos:8002;    
+    }
+   
     location / {
         proxy_pass http://vachan-api:8000;
     }

--- a/docker/production-deploy.yml
+++ b/docker/production-deploy.yml
@@ -97,7 +97,7 @@ services:
    - my-network
 
  vachan-demos:
-    image: kavitha3797/vachan-demos:2.0.0-alpha.2
+    image: kavitha3797/vachan-demos:latest
     expose:
       - 8002
     command: uvicorn main:app --host 0.0.0.0 --port 8002

--- a/docker/production-deploy.yml
+++ b/docker/production-deploy.yml
@@ -96,6 +96,20 @@ services:
   networks:
    - my-network
 
+ vachan-demos:
+    image: kavitha3797/vachan-demos:2.0.0-alpha.2
+    expose:
+      - 8002
+    command: uvicorn main:app --host 0.0.0.0 --port 8002
+    restart: always
+    environment:
+     - VACHAN_DOMAIN=${VACHAN_DOMAIN:-api.vachanengine.org}
+     - VACHAN_LOGGING_LEVEL=INFO
+    volumes:
+     - logs-vol:/app/logs
+    networks:
+     - my-network
+
 #reddis
  redis:
   container_name: redis


### PR DESCRIPTION
- A tiny step towards the dream of https://github.com/Bridgeconn/vachan-api/discussions/533 
- Pulls the docker image of vachan-demos micro-service published separately at docker-hub.
- Uses NGINX to route API calls starting with `v2/demos/` to the new container added in docker compose