### PR TITLE
Move auth db to main docker compose

### DIFF
--- a/docker/production-deploy.yml
+++ b/docker/production-deploy.yml
@@ -1,5 +1,39 @@
 version: '3.9'
 services:
+ kratos-migrate:
+    image: oryd/kratos:v0.7.0-alpha.1
+    environment:
+      - DSN=${VACHAN_AUTH_DATABASE:-postgres://kratos:secret@postgresd:5432/kratos?sslmode=disable&max_conns=20&max_idle_conns=4}
+    volumes:
+      - type: volume
+        source: kratos-sqlite
+        target: /var/lib/sqlite
+        read_only: false
+      - type: bind
+        source: ./Kratos_config/email-password
+        target: /etc/config/kratos
+    command: -c /etc/config/kratos/kratos.yml migrate sql -e --yes
+    restart: on-failure
+    depends_on:
+      - postgresd
+    networks:
+      - my-network
+
+ postgresd:
+    image: postgres:9.6
+    ports:
+      - "5432:5432"
+    restart: always
+    environment:
+      - POSTGRES_USER=${VACHAN_KRATOS_DB_USER:-kratos}
+      - POSTGRES_PASSWORD=${VACHAN_KRATOS_DB_PASSWORD:-secret}
+      - POSTGRES_DB=${VACHAN_KRATOS_DB_NAME:-kratos}
+      - POSTGRES_HOST_AUTH_METHOD=md5
+    networks:
+      - my-network
+    volumes: 
+      - kratos-postgres-vol:/var/lib/postgresql/data
+ 
  kratos:
   image: oryd/kratos:v0.7.0-alpha.1
   ports:
@@ -238,4 +272,5 @@ volumes:
   vachan-db-vol:
   logs-vol:
   redis-data:
-  # kratos-sqlite:
+  kratos-sqlite:
+  kratos-postgres-vol:

--- a/docs/docker-guide.md
+++ b/docs/docker-guide.md
@@ -74,21 +74,13 @@ To turn down the running containers
 ## To deploy on server
 Install docker, docker-compose & git and set up the right repo and branch. 
 
-In the production-deploy version, we would connect the app to the centrally hosted Kratos user DB.
-(To start that DB, in the same or different server, use the [this](../docker/Kratos_config/database.yml) docker-compose file.)
-```
-cd Kratos_config
-docker-compose -f database.yml up -d
-cd ..
-```
-
 Back in the vachan-api server,along with VACHAN_SUPER_USERNAME and VACHAN_SUPER_PASSWORD, need to set VACHAN_AUTH_DATABASE, VACHAN_SUPPORT_EMAIL_CREDS and VACHAN_SUPPORT_EMAIL as environment variables along with other required values, in the `prod.env` file.
 
 Refer the following format
 ```
 VACHAN_SUPER_USERNAME="<super-admin-emial-id>"
 VACHAN_SUPER_PASSWORD="<a-strong-password>"
-VACHAN_AUTH_DATABASE="postgresql://<DB-user>:<DB-passwords>@<server-ip>:<DB-port>/<DB-name>"
+VACHAN_AUTH_DATABASE="postgresql://<DB-user>:<DB-passwords>@postgresd:<DB-port>/<DB-name>"
 VACHAN_SUPPORT_EMAIL_CREDS="smtps://<email-id>:<password>:<email-service>:<smtp-port>/?skip_ssl_verify=true&legacy_ssl=true"
 VACHAN_SUPPORT_EMAIL="<email-id>"
 ```


### PR DESCRIPTION
Earlier we were hosting the Auth DB separately, not within the production-deploy.yml docker-compose file.
Recently we had two incidents where the DB conection to this container outside failed, once in ISL deployment and then in the production deployment. 
In this PR, bringing the auth DB also into the main docker-compose file used for deployment.