### PR TITLE
Feature/new app sanketmast

### DIFF
--- a/app/auth/access_rules.json
+++ b/app/auth/access_rules.json
@@ -18,35 +18,35 @@
     "open-access":{
         "read-via-api":["noAuthRequired"],
         "view-on-web":["noAuthRequired"],
-        "refer-for-translation": ["SuperAdmin", "AgAdmin", "AgUser"],
-        "translate":["SuperAdmin", "AgAdmin", "AgUser"]
+        "refer-for-translation": ["SuperAdmin", "AgAdmin", "SanketMASTAdmin", "AgUser", "SanketMASTUser"],
+        "translate":["SuperAdmin", "AgAdmin", "SanketMASTAdmin", "AgUser", "SanketMASTUser"]
     },
     "editable":{
-        "create": ["SuperAdmin", "VachanAdmin", "AgAdmin", "AgUser"],
-        "edit": ["SuperAdmin", "VachanAdmin", "AgAdmin", "AgUser"]
+        "create": ["SuperAdmin", "VachanAdmin", "AgAdmin", "SanketMASTAdmin", "AgUser", "SanketMASTUser"],
+        "edit": ["SuperAdmin", "VachanAdmin", "AgAdmin", "SanketMASTAdmin", "AgUser", "SanketMASTUser"]
     },
     "publishable":{
         "read-via-api":["registeredUser"],
         "view-on-web":["noAuthRequired"],
-        "refer-for-translation":["SuperAdmin", "AgAdmin", "AgUser"]
+        "refer-for-translation":["SuperAdmin", "AgAdmin", "SanketMASTAdmin", "AgUser", "SanketMASTUser"]
     },
     "downloadable":{
         "download-n-save":["SuperAdmin", "VachanAdmin", "VachanUser"]
     },
     "derivable":{
-        "translate":["SuperAdmin", "AgAdmin", "AgUser"]
+        "translate":["SuperAdmin", "AgAdmin", "SanketMASTAdmin", "AgUser", "SanketMASTUser"]
     },
     "translation-project":{
-        "create":["SuperAdmin", "AgAdmin", "AgUser"],
-        "delete":["SuperAdmin", "AgAdmin", "projectOwner"],
-        "create-user":["SuperAdmin", "AgAdmin", "projectOwner"],
-        "delete-user":["SuperAdmin", "AgAdmin", "projectOwner"],
-        "edit-Settings":["SuperAdmin", "AgAdmin", "projectOwner"],
-        "read-settings":["SuperAdmin", "AgAdmin", "projectOwner", "projectMember"],
-        "edit-draft": ["SuperAdmin", "AgAdmin", "projectOwner", "projectMember"],
-        "read-draft":["SuperAdmin", "AgAdmin", "projectOwner", "projectMember", "BcsDeveloper"],
-        "view-project":["SuperAdmin", "AgAdmin", "projectOwner", "projectMember", "BcsDeveloper"],
-        "delete-sentence": ["SuperAdmin", "AgAdmin", "projectOwner","projectMember"]
+        "create":["SuperAdmin", "AgAdmin", "SanketMASTAdmin", "AgUser", "SanketMASTUser"],
+        "delete":["SuperAdmin", "AgAdmin", "SanketMASTAdmin", "projectOwner"],
+        "create-user":["SuperAdmin", "AgAdmin", "SanketMASTAdmin", "projectOwner"],
+        "delete-user":["SuperAdmin", "AgAdmin", "SanketMASTAdmin", "projectOwner"],
+        "edit-Settings":["SuperAdmin", "AgAdmin", "SanketMASTAdmin", "projectOwner"],
+        "read-settings":["SuperAdmin", "AgAdmin", "SanketMASTAdmin", "projectOwner", "projectMember"],
+        "edit-draft": ["SuperAdmin", "AgAdmin", "SanketMASTAdmin", "projectOwner", "projectMember"],
+        "read-draft":["SuperAdmin", "AgAdmin", "SanketMASTAdmin", "projectOwner", "projectMember", "BcsDeveloper"],
+        "view-project":["SuperAdmin", "AgAdmin", "SanketMASTAdmin", "projectOwner", "projectMember", "BcsDeveloper"],
+        "delete-sentence": ["SuperAdmin", "AgAdmin", "SanketMASTAdmin", "projectOwner","projectMember"]
     },
     "generic-translation":{
         "read":["registeredUser"],

--- a/app/auth/api-permissions.csv
+++ b/app/auth/api-permissions.csv
@@ -8,12 +8,14 @@ Endpoints,Method,RequestApp,FilterResults,ResourceType,Permission
 /v2/user/role,PUT,None,False,None,edit-role
 /v2/user/delete-identity,DELETE,None,False,None,delete/deactivate
 /v2/contents,GET,Autographa,False,None,refer-for-translation
+/v2/contents,GET,SanketMAST,False,None,refer-for-translation
 /v2/contents,GET,Vachan-online or vachan-app,False,None,view-on-web
 /v2/contents,GET,VachanAdmin,False,None,read-via-vachanadmin
 /v2/contents,GET,API-user,False,None,read-via-api
 /v2/contents,POST,None,False,None,create
 /v2/contents,DELETE,None,False,None,delete/deactivate
 /v2/languages,GET,Autographa,False,None,refer-for-translation
+/v2/languages,GET,SanketMAST,False,None,refer-for-translation
 /v2/languages,GET,Vachan-online or vachan-app,False,None,view-on-web
 /v2/languages,GET,VachanAdmin,False,None,read-via-vachanadmin
 /v2/languages,GET,API-user,False,None,read-via-api
@@ -21,6 +23,7 @@ Endpoints,Method,RequestApp,FilterResults,ResourceType,Permission
 /v2/languages,PUT,None,False,None,edit
 /v2/languages,DELETE,None,False,None,delete/deactivate
 /v2/licenses,GET,Autographa,False,None,refer-for-translation
+/v2/licenses,GET,SanketMAST,False,None,refer-for-translation
 /v2/licenses,GET,Vachan-online or vachan-app,False,None,view-on-web
 /v2/licenses,GET,VachanAdmin,False,None,read-via-vachanadmin
 /v2/licenses,GET,API-user,False,None,read-via-api
@@ -28,6 +31,7 @@ Endpoints,Method,RequestApp,FilterResults,ResourceType,Permission
 /v2/licenses,PUT,None,False,None,edit
 /v2/licenses,DELETE,None,False,None,delete/deactivate
 /v2/versions,GET,Autographa,False,None,refer-for-translation
+/v2/versions,GET,SanketMAST,False,None,refer-for-translation
 /v2/versions,GET,Vachan-online or vachan-app,False,None,view-on-web
 /v2/versions,GET,VachanAdmin,False,None,read-via-vachanadmin
 /v2/versions,GET,API-user,False,None,read-via-api
@@ -35,6 +39,7 @@ Endpoints,Method,RequestApp,FilterResults,ResourceType,Permission
 /v2/versions,PUT,None,False,None,edit
 /v2/versions,DELETE,None,False,None,delete/deactivate
 /v2/sources,GET,Autographa,True,None,refer-for-translation
+/v2/sources,GET,SanketMAST,True,None,refer-for-translation
 /v2/sources,GET,Vachan-online or vachan-app,True,None,view-on-web
 /v2/sources,GET,VachanAdmin,True,None,read-via-vachanadmin
 /v2/sources,GET,API-user,True,None,read-via-api
@@ -42,12 +47,14 @@ Endpoints,Method,RequestApp,FilterResults,ResourceType,Permission
 /v2/sources,PUT,None,False,None,edit
 /v2/sources,DELETE,None,False,None,delete/deactivate
 /v2/sources/get-sentence,GET,Autographa,False,"contents like bibles, commentaries, infographics, dictionary or videos",refer-for-translation
+/v2/sources/get-sentence,GET,SanketMAST,False,"contents like bibles, commentaries, infographics, dictionary or videos",refer-for-translation
 /v2/sources/get-sentence,GET,Vachan-online or vachan-app,False,"contents like bibles, commentaries, infographics, dictionary or videos",view-on-web
 /v2/sources/get-sentence,GET,VachanAdmin,False,"contents like bibles, commentaries, infographics, dictionary or videos",read-via-vachanadmin
 /v2/sources/get-sentence,GET,API-user,False,"contents like bibles, commentaries, infographics, dictionary or videos",read-via-api
 /v2/sources/get-sentence,GET,None,False,Research-Material,read-via-api
 /v2/lookup/bible/books,GET,None,False,None,read
 /v2/bibles/{source_name}/books,GET,Autographa,False,None,refer-for-translation
+/v2/bibles/{source_name}/books,GET,SanketMAST,False,None,refer-for-translation
 /v2/bibles/{source_name}/books,GET,Vachan-online or vachan-app,False,None,view-on-web
 /v2/bibles/{source_name}/books,GET,VachanAdmin,False,None,read-via-vachanadmin
 /v2/bibles/{source_name}/books,GET,API-user,False,None,read-via-api
@@ -55,10 +62,12 @@ Endpoints,Method,RequestApp,FilterResults,ResourceType,Permission
 /v2/bibles/{source_name}/books,PUT,None,False,None,edit
 /v2/bibles/{source_name}/books,DELETE,None,False,None,delete/deactivate
 /v2/bibles/{source_name}/versification,GET,Autographa,False,None,refer-for-translation
+/v2/bibles/{source_name}/versification,GET,SanketMAST,False,None,refer-for-translation
 /v2/bibles/{source_name}/versification,GET,Vachan-online or vachan-app,False,None,view-on-web
 /v2/bibles/{source_name}/versification,GET,VachanAdmin,False,None,read-via-vachanadmin
 /v2/bibles/{source_name}/versification,GET,API-user,False,None,read-via-api
 /v2/bibles/{source_name}/verses,GET,Autographa,False,None,refer-for-translation
+/v2/bibles/{source_name}/verses,GET,SanketMAST,False,None,refer-for-translation
 /v2/bibles/{source_name}/verses,GET,Vachan-online or vachan-app,False,None,view-on-web
 /v2/bibles/{source_name}/verses,GET,VachanAdmin,False,None,read-via-vachanadmin
 /v2/bibles/{source_name}/verses,GET,API-user,False,None,read-via-api
@@ -66,6 +75,7 @@ Endpoints,Method,RequestApp,FilterResults,ResourceType,Permission
 /v2/bibles/{source_name}/audios,PUT,None,False,None,edit
 /v2/bibles/{source_name}/audios,DELETE,None,False,None,delete/deactivate
 /v2/commentaries/{source_name},GET,Autographa,False,None,refer-for-translation
+/v2/commentaries/{source_name},GET,SanketMAST,False,None,refer-for-translation
 /v2/commentaries/{source_name},GET,Vachan-online or vachan-app,False,None,view-on-web
 /v2/commentaries/{source_name},GET,VachanAdmin,False,None,read-via-vachanadmin
 /v2/commentaries/{source_name},GET,API-user,False,None,read-via-api
@@ -73,10 +83,12 @@ Endpoints,Method,RequestApp,FilterResults,ResourceType,Permission
 /v2/commentaries/{source_name},PUT,None,False,None,edit
 /v2/commentaries/{source_name},DELETE,None,False,None,delete/deactivate
 /v2/dictionaries/{source_name},GET,Autographa,False,None,refer-for-translation
+/v2/dictionaries/{source_name},GET,SanketMAST,False,None,refer-for-translation
 /v2/dictionaries/{source_name},GET,Vachan-online or vachan-app,False,None,view-on-web
 /v2/dictionaries/{source_name},GET,VachanAdmin,False,None,read-via-vachanadmin
 /v2/dictionaries/{source_name},GET,API-user,False,None,read-via-api
 /v2/dictionaries/{source_name}/count,GET,Autographa,False,None,refer-for-translation
+/v2/dictionaries/{source_name}/count,GET,SanketMAST,False,None,refer-for-translation
 /v2/dictionaries/{source_name}/count,GET,Vachan-online or vachan-app,False,None,view-on-web
 /v2/dictionaries/{source_name}/count,GET,VachanAdmin,False,None,read-via-vachanadmin
 /v2/dictionaries/{source_name}/count,GET,API-user,False,None,read-via-api
@@ -84,6 +96,7 @@ Endpoints,Method,RequestApp,FilterResults,ResourceType,Permission
 /v2/dictionaries/{source_name},PUT,None,False,None,edit
 /v2/dictionaries/{source_name},DELETE,None,False,None,delete/deactivate
 /v2/infographics/{source_name},GET,Autographa,False,None,refer-for-translation
+/v2/infographics/{source_name},GET,SanketMAST,False,None,refer-for-translation
 /v2/infographics/{source_name},GET,Vachan-online or vachan-app,False,None,view-on-web
 /v2/infographics/{source_name},GET,VachanAdmin,False,None,read-via-vachanadmin
 /v2/infographics/{source_name},GET,API-user,False,None,read-via-api
@@ -91,6 +104,7 @@ Endpoints,Method,RequestApp,FilterResults,ResourceType,Permission
 /v2/infographics/{source_name},PUT,None,False,None,edit
 /v2/infographics/{source_name},DELETE,None,False,None,delete/deactivate
 /v2/biblevideos/{source_name},GET,Autographa,False,None,refer-for-translation
+/v2/biblevideos/{source_name},GET,SanketMAST,False,None,refer-for-translation
 /v2/biblevideos/{source_name},GET,Vachan-online or vachan-app,False,None,view-on-web
 /v2/biblevideos/{source_name},GET,VachanAdmin,False,None,read-via-vachanadmin
 /v2/biblevideos/{source_name},GET,API-user,False,None,read-via-api
@@ -98,24 +112,43 @@ Endpoints,Method,RequestApp,FilterResults,ResourceType,Permission
 /v2/biblevideos/{source_name},PUT,None,False,None,edit
 /v2/biblevideos/{source_name},DELETE,None,False,None,delete/deactivate
 /v2/translation/projects,GET,Autographa,True,None,view-project
+/v2/translation/projects,GET,SanketMAST,True,None,view-project
 /v2/translation/projects,POST,Autographa,False,None,create
+/v2/translation/projects,POST,SanketMAST,False,None,create
 /v2/translation/projects,PUT,Autographa,False,"contents like bibles, commentaries, infographics, dictionary or videos",translate
+/v2/translation/projects,PUT,SanketMAST,False,"contents like bibles, commentaries, infographics, dictionary or videos",translate
 /v2/translation/projects,PUT,Autographa,False,Ag or translation project,edit-Settings
+/v2/translation/projects,PUT,SanketMAST,False,Ag or translation project,edit-Settings
 /v2/translation/projects,DELETE,Autographa,False,None,delete
+/v2/translation/projects,DELETE,SanketMAST,False,None,delete
 /v2/translation/project/user,POST,Autographa,False,None,create-user
+/v2/translation/project/user,POST,SanketMAST,False,None,create-user
 /v2/translation/project/user,PUT,Autographa,False,None,edit-Settings
+/v2/translation/project/user,PUT,SanketMAST,False,None,edit-Settings
 /v2/translation/project/user,DELETE,Autographa,False,None,delete-user
+/v2/translation/project/user,DELETE,SanketMAST,False,None,delete-user
 /v2/translation/project/tokens,GET,Autographa,False,None,read-draft
+/v2/translation/project/tokens,GET,SanketMAST,False,None,read-draft
 /v2/translation/project/tokens,PUT,Autographa,False,None,edit-draft
+/v2/translation/project/tokens,PUT,SanketMAST,False,None,edit-draft
 /v2/translation/project/token-translations,GET,Autographa,False,None,read-draft
+/v2/translation/project/token-translations,GET,SanketMAST,False,None,read-draft
 /v2/translation/project/token-sentences,PUT,Autographa,False,None,edit-draft
+/v2/translation/project/token-sentences,PUT,SanketMAST,False,None,edit-draft
 /v2/translation/project/draft,GET,Autographa,False,None,read-draft
+/v2/translation/project/draft,GET,SanketMAST,False,None,read-draft
 /v2/translation/project/draft,PUT,Autographa,False,None,edit-draft
+/v2/translation/project/draft,PUT,SanketMAST,False,None,edit-draft
 /v2/translation/project/sentences,GET,Autographa,False,None,view-project
+/v2/translation/project/sentences,GET,SanketMAST,False,None,view-project
 /v2/translation/project/progress,GET,Autographa,False,None,view-project
+/v2/translation/project/progress,GET,SanketMAST,False,None,view-project
 /v2/translation/project/versification,GET,Autographa,False,None,view-project
+/v2/translation/project/versification,GET,SanketMAST,False,None,view-project
 /v2/translation/project/sentences,DELETE,Autographa,False,None,delete-sentence
+/v2/translation/project/sentences,DELETE,SanketMAST,False,None,delete-sentence
 /v2/translation/project/suggestions,PUT,Autographa,False,None,edit-draft
+/v2/translation/project/suggestions,PUT,SanketMAST,False,None,edit-draft
 /v2/translation/suggestions,PUT,None,False,None,process
 /v2/translation/tokens,PUT,None,False,None,process
 /v2/translation/token-translate,PUT,None,False,None,process
@@ -139,6 +172,7 @@ Endpoints,Method,RequestApp,FilterResults,ResourceType,Permission
 /v2/media/gitlab/download,GET,None,False,Media contents,download
 /v2/media/gitlab/download,GET,None,False,"contents like bibles, commentaries, infographics, dictionary or videos",read-via-api
 /v2/bibles/{source_name}/books/{book_code}/format/{output_format},GET,Autographa,False,None,refer-for-translation
+/v2/bibles/{source_name}/books/{book_code}/format/{output_format},GET,SanketMAST,False,None,refer-for-translation
 /v2/bibles/{source_name}/books/{book_code}/format/{output_format},GET,Vachan-online or vachan-app,False,None,view-on-web
 /v2/bibles/{source_name}/books/{book_code}/format/{output_format},GET,VachanAdmin,False,None,read-via-vachanadmin
 /v2/bibles/{source_name}/books/{book_code}/format/{output_format},GET,API-user,False,None,read-via-api

--- a/app/auth/authentication.py
+++ b/app/auth/authentication.py
@@ -492,7 +492,7 @@ def register_check_success(reg_response):
     user_permision = data["registered_details"]['Permissions']
     switcher = {
         schema_auth.AdminRoles.AGUSER.value : schema_auth.App.AG.value,
-        schema_auth.AdminRoles.SAMSTUSER.value : schema_auth.App.SMAST.value,
+        schema_auth.AdminRoles.SMASTUSER.value : schema_auth.App.SMAST.value,
         schema_auth.AdminRoles.VACHANUSER.value : schema_auth.App.VACHAN.value,
         # schema_auth.AdminRoles.VACHANADMIN.value : schema_auth.AdminRoles.VACHANADMIN.value
             }
@@ -541,7 +541,7 @@ def register_flow_fail(reg_response,email,user_role,reg_req):
             for perm in user_permision:
                 switcher = {
                     schema_auth.AdminRoles.AGUSER.value : schema_auth.App.AG.value,
-                    schema_auth.AdminRoles.SMAST.value : schema_auth.App.SMAST.value,
+                    schema_auth.AdminRoles.SMASTUSER.value : schema_auth.App.SMAST.value,
                     schema_auth.AdminRoles.VACHANUSER.value : schema_auth.App.VACHAN.value,
                     # schema_auth.AdminRoles.VACHANADMIN.value : schema_auth.App.VACHANADMIN.value
                     }

--- a/app/auth/authentication.py
+++ b/app/auth/authentication.py
@@ -395,7 +395,8 @@ def get_users_kratos_filter(base_url,name,roles,limit,skip):#pylint: disable=too
                 switcher = {
                     schema_auth.FilterRoles.AG.value : schema_auth.FilterRoles.AG,
                     schema_auth.FilterRoles.VACHAN.value : schema_auth.FilterRoles.VACHAN,
-                    schema_auth.FilterRoles.API.value : schema_auth.FilterRoles.API
+                    schema_auth.FilterRoles.API.value : schema_auth.FilterRoles.API,
+                    schema_auth.FilterRoles.SMAST.value : schema_auth.FilterRoles.SMAST
                         }
                 for role in roles:
                     user_role =  switcher.get(role)
@@ -491,6 +492,7 @@ def register_check_success(reg_response):
     user_permision = data["registered_details"]['Permissions']
     switcher = {
         schema_auth.AdminRoles.AGUSER.value : schema_auth.App.AG.value,
+        schema_auth.AdminRoles.SAMSTUSER.value : schema_auth.App.SMAST.value,
         schema_auth.AdminRoles.VACHANUSER.value : schema_auth.App.VACHAN.value,
         # schema_auth.AdminRoles.VACHANADMIN.value : schema_auth.AdminRoles.VACHANADMIN.value
             }
@@ -539,6 +541,7 @@ def register_flow_fail(reg_response,email,user_role,reg_req):
             for perm in user_permision:
                 switcher = {
                     schema_auth.AdminRoles.AGUSER.value : schema_auth.App.AG.value,
+                    schema_auth.AdminRoles.SMAST.value : schema_auth.App.SMAST.value,
                     schema_auth.AdminRoles.VACHANUSER.value : schema_auth.App.VACHAN.value,
                     # schema_auth.AdminRoles.VACHANADMIN.value : schema_auth.App.VACHANADMIN.value
                     }
@@ -563,6 +566,7 @@ def user_register_kratos(register_details,app_type):
 
     switcher = {
         schema_auth.App.AG : schema_auth.AdminRoles.AGUSER.value,
+        schema_auth.App.SMAST : schema_auth.AdminRoles.SMASTUSER.value,
         schema_auth.App.VACHAN: schema_auth.AdminRoles.VACHANUSER.value,
         # schema_auth.App.VACHANADMIN: schema_auth.AdminRoles.VACHANADMIN.value
             }

--- a/app/graphql_api/types.py
+++ b/app/graphql_api/types.py
@@ -717,12 +717,14 @@ class App(graphene.Enum):
     VACHAN = "Vachan-online or vachan-app"
     VACHANADMIN = "VachanAdmin"
     API = "API-user"
+    SMAST = "SanketMAST"
 
 class AppInput(graphene.Enum):
     '''available choices for permission'''
     AG = "Autographa"
     VACHAN = "Vachan-online or vachan-app"
     API = "API-user"
+    SMAST = "SanketMAST"
 
 class RegisterInput(graphene.InputObjectType):
     """Register Input"""
@@ -743,6 +745,7 @@ class FilterRoles(graphene.Enum):
     AG = "Autographa"
     VACHAN = "Vachan-online or vachan-app"
     API = "API-user"
+    SMAST = "SanketMAST"
 
 class IdentitityListResponse(graphene.ObjectType):#pylint: disable=too-few-public-methods
     """Response object of getusers"""
@@ -770,10 +773,12 @@ class AdminRoles(graphene.Enum):
     SUPERADMIN = 'SuperAdmin'
     VACHANADMIN = 'VachanAdmin'
     AGADMIN = 'AgAdmin'
+    SMASTADMIN = "SanketMASTAdmin"
     AGUSER = 'AgUser'
     VACHANUSER = 'VachanUser'
     APIUSER = 'APIUser'
     BCSDEV = 'BcsDeveloper'
+    SMASTUSER = "SanketMASTUser"
 
 class UserroleInput(graphene.InputObjectType):
     """input for user role update"""

--- a/app/main.py
+++ b/app/main.py
@@ -27,7 +27,7 @@ if os.environ.get("VACHAN_TEST_MODE", "False") != 'True':
 
     create_super_user()
 
-app = FastAPI(title="Vachan-API", version="2.0.0-beta.7",
+app = FastAPI(title="Vachan-API", version="2.0.0-beta.8",
     description="The server application that provides APIs to interact \
 with the underlying Databases and modules in Vachan-Engine.")
 

--- a/app/schema/schema_auth.py
+++ b/app/schema/schema_auth.py
@@ -25,12 +25,14 @@ class App(str, Enum):
     VACHAN = "Vachan-online or vachan-app"
     API = "API-user"
     VACHANADMIN = "VachanAdmin"
+    SMAST = "SanketMAST"
 
 class AppInput(str, Enum):
     '''Input fields for App in Registration'''
     AG = "Autographa"
     VACHAN = "Vachan-online or vachan-app"
     API = "API-user"
+    SMAST = "SanketMAST"
 
 class Registration(BaseModel):
     """kratos registration input"""
@@ -53,6 +55,8 @@ class AdminRoles(str, Enum):
     VACHANUSER = 'VachanUser'
     APIUSER = 'APIUser'
     BCSDEV = 'BcsDeveloper'
+    SMASTADMIN = 'SanketMASTAdmin'
+    SMASTUSER = 'SanketMASTUser'
 
 class FilterRoles(str, Enum):
     '''Filter roles for get users'''
@@ -60,6 +64,7 @@ class FilterRoles(str, Enum):
     AG = "Autographa"
     VACHAN = "Vachan-online or vachan-app"
     API = "API-user"
+    SMAST = "SanketMAST"
 
 class UserRole(BaseModel):
     """kratos user role input"""

--- a/app/test/__init__.py
+++ b/app/test/__init__.py
@@ -1125,9 +1125,10 @@ def contetapi_get_accessrule_checks_app_userroles_gql(contenttype, content_qry, 
 
     API = types.App.API.value
     AG = types.App.AG.value
+    SMAST = types.App.SMAST.value
     VACHAN = types.App.VACHAN.value
     VACHANADMIN = types.App.VACHANADMIN.value
-    Apps = [ API,AG,VACHAN,VACHANADMIN]
+    Apps = [ API,AG,VACHAN,VACHANADMIN,SMAST]
 
     #Get without Login headers=headers_auth
     #permision -------------------------> content , downloadable , derivable
@@ -1287,8 +1288,8 @@ def contetapi_get_accessrule_checks_app_userroles_gql(contenttype, content_qry, 
                 assert "errors" in response
         print(f"Test passed -----> AG ADMIN")
 
-        #Get with SannketMASTAdmin
-        headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SannketMASTAdmin']['token']
+        #Get with SanketMASTAdmin
+        headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
         for num in range(4):
             headers_auth['app'] = Apps[num]
             if bible:
@@ -1306,7 +1307,7 @@ def contetapi_get_accessrule_checks_app_userroles_gql(contenttype, content_qry, 
                 response = gql_request(query= test_data["get_query"], variables=test_data["get_var"],
                     headers=headers_auth)
                 assert "errors" in response
-        print(f"Test passed -----> SannketMASTAdmin")
+        print(f"Test passed -----> SanketMASTAdmin")
 
         #Get with SuperAdmin
         headers_auth['Authorization'] = SA_TOKEN

--- a/app/test/__init__.py
+++ b/app/test/__init__.py
@@ -261,9 +261,10 @@ def contetapi_get_accessrule_checks_app_userroles(contenttype, UNIT_URL, data , 
 
     API = schema_auth.App.API.value
     AG = schema_auth.App.AG.value
+    SMAST = schema_auth.App.SMAST.value
     VACHAN = schema_auth.App.VACHAN.value
     VACHANADMIN = schema_auth.AdminRoles.VACHANADMIN.value
-    Apps = [ API,AG,VACHAN,VACHANADMIN]
+    Apps = [ API,AG,VACHAN,VACHANADMIN, SMAST]
 
     #Get without Login headers=headers_auth
     #permision -------------------------> content , downloadable , derivable
@@ -313,6 +314,26 @@ def contetapi_get_accessrule_checks_app_userroles(contenttype, UNIT_URL, data , 
                 assert response.status_code == 403
                 assert response.json()["error"] == "Permission Denied"
         print(f"Test passed -----> AG USER")
+
+        #Get with SanketMASTUser
+        headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
+        for num in range(4):
+            headers_auth['app'] = Apps[num]
+            if bible:
+                response = client.get(UNIT_URL+test_permissions_list[i]+'/books',headers=headers_auth)
+                assert response.status_code == 403
+                assert response.json()["error"] == "Permission Denied"
+                response = client.get(UNIT_URL+test_permissions_list[i]+'/versification',headers=headers_auth)
+                assert response.status_code == 403
+                assert response.json()["error"] == "Permission Denied"
+                response = client.get(UNIT_URL+test_permissions_list[i]+'/verses',headers=headers_auth)
+                assert response.status_code == 403
+                assert response.json()["error"] == "Permission Denied"
+            else:
+                response = client.get(UNIT_URL+test_permissions_list[i],headers=headers_auth)
+                assert response.status_code == 403
+                assert response.json()["error"] == "Permission Denied"
+        print(f"Test passed -----> SanketMASTUser")
 
         #Get with VachanUser
         headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['VachanUser']['token']
@@ -401,6 +422,26 @@ def contetapi_get_accessrule_checks_app_userroles(contenttype, UNIT_URL, data , 
                 assert response.status_code == 403
                 assert response.json()["error"] == "Permission Denied"
         print(f"Test passed -----> AG ADMIN")
+
+        #Get with SanketMASTAdmin
+        headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+        for num in range(4):
+            headers_auth['app'] = Apps[num]
+            if bible:
+                response = client.get(UNIT_URL+test_permissions_list[i]+'/books',headers=headers_auth)
+                assert response.status_code == 403
+                assert response.json()["error"] == "Permission Denied"
+                response = client.get(UNIT_URL+test_permissions_list[i]+'/versification',headers=headers_auth)
+                assert response.status_code == 403
+                assert response.json()["error"] == "Permission Denied"
+                response = client.get(UNIT_URL+test_permissions_list[i]+'/verses',headers=headers_auth)
+                assert response.status_code == 403
+                assert response.json()["error"] == "Permission Denied"
+            else:
+                response = client.get(UNIT_URL+test_permissions_list[i],headers=headers_auth)
+                assert response.status_code == 403
+                assert response.json()["error"] == "Permission Denied"
+        print(f"Test passed -----> SanketMASTAdmin")
 
         #Get with SuperAdmin
         headers_auth['Authorization'] = SA_TOKEN
@@ -520,6 +561,36 @@ def contetapi_get_accessrule_checks_app_userroles(contenttype, UNIT_URL, data , 
                 assert response.json()["error"] == "Permission Denied"
     print(f"Test passed -----> AG USER")
 
+    #Get with SanketMASTUser
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
+    for num in range(4):
+        headers_auth['app'] = Apps[num]
+        if bible:
+            response1 = client.get(UNIT_URL+sourcename_list[1]+'/books',headers=headers_auth)
+            response2 = client.get(UNIT_URL+sourcename_list[1]+'/versification',headers=headers_auth)
+            response3 = client.get(UNIT_URL+sourcename_list[1]+'/verses',headers=headers_auth)
+            if headers_auth['app'] == API or headers_auth['app'] == VACHAN\
+                or headers_auth['app'] == AG:
+                assert response1.status_code == 200
+                assert response2.status_code == 200
+                assert response3.status_code == 200
+            else:
+                assert response1.status_code == 403
+                assert response1.json()["error"] == "Permission Denied"
+                assert response2.status_code == 403
+                assert response2.json()["error"] == "Permission Denied"
+                assert response3.status_code == 403
+                assert response3.json()["error"] == "Permission Denied"
+        else:
+            response = client.get(UNIT_URL+sourcename_list[1],headers=headers_auth)
+            if headers_auth['app'] == API or headers_auth['app'] == VACHAN\
+                or headers_auth['app'] == AG:
+                assert response.status_code == 200
+            else:    
+                assert response.status_code == 403
+                assert response.json()["error"] == "Permission Denied"
+    print(f"Test passed -----> SanketMASTUser")
+
     #Get with VachanUser
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['VachanUser']['token']
     for num in range(4):
@@ -635,6 +706,36 @@ def contetapi_get_accessrule_checks_app_userroles(contenttype, UNIT_URL, data , 
                 assert response.status_code == 403
                 assert response.json()["error"] == "Permission Denied"
     print(f"Test passed -----> AG ADMIN")
+
+    #Get with SanketMASTAdmin
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    for num in range(4):
+        headers_auth['app'] = Apps[num]
+        if bible:
+            response1 = client.get(UNIT_URL+sourcename_list[1]+'/books',headers=headers_auth)
+            response2 = client.get(UNIT_URL+sourcename_list[1]+'/versification',headers=headers_auth)
+            response3 = client.get(UNIT_URL+sourcename_list[1]+'/verses',headers=headers_auth)
+            if headers_auth['app'] == API or headers_auth['app'] == VACHAN\
+                or headers_auth['app'] == AG:
+                assert response1.status_code == 200
+                assert response2.status_code == 200
+                assert response3.status_code == 200
+            else:
+                assert response1.status_code == 403
+                assert response1.json()["error"] == "Permission Denied"
+                assert response2.status_code == 403
+                assert response2.json()["error"] == "Permission Denied"
+                assert response3.status_code == 403
+                assert response3.json()["error"] == "Permission Denied"
+        else:
+            response = client.get(UNIT_URL+sourcename_list[1],headers=headers_auth)
+            if headers_auth['app'] == API or headers_auth['app'] == VACHAN\
+                or headers_auth['app'] == AG:
+                assert response.status_code == 200
+            else:    
+                assert response.status_code == 403
+                assert response.json()["error"] == "Permission Denied"
+    print(f"Test passed -----> SanketMASTAdmin")
 
     #Get with SuperAdmin
     headers_auth['Authorization'] = SA_TOKEN
@@ -742,6 +843,36 @@ def contetapi_get_accessrule_checks_app_userroles(contenttype, UNIT_URL, data , 
                 assert response.json()["error"] == "Permission Denied"
     print(f"Test passed -----> AG USER")
 
+    #Get with SanketMASTUser
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
+    for num in range(4):
+        headers_auth['app'] = Apps[num]
+        if bible:
+            response1 = client.get(UNIT_URL+sourcename_list[2]+'/books',headers=headers_auth)
+            response2 = client.get(UNIT_URL+sourcename_list[2]+'/versification',headers=headers_auth)
+            response3 = client.get(UNIT_URL+sourcename_list[2]+'/verses',headers=headers_auth)
+            if headers_auth['app'] == VACHAN or headers_auth['app'] == AG\
+                or headers_auth['app'] == API:
+                assert response1.status_code == 200
+                assert response2.status_code == 200
+                assert response3.status_code == 200
+            else:
+                assert response1.status_code == 403
+                assert response1.json()["error"] == "Permission Denied"
+                assert response2.status_code == 403
+                assert response2.json()["error"] == "Permission Denied"
+                assert response3.status_code == 403
+                assert response3.json()["error"] == "Permission Denied"
+        else:
+            response = client.get(UNIT_URL+sourcename_list[2],headers=headers_auth)
+            if headers_auth['app'] == VACHAN or headers_auth['app'] == AG\
+                or headers_auth['app'] == API:
+                assert response.status_code == 200
+            else:    
+                assert response.status_code == 403
+                assert response.json()["error"] == "Permission Denied"
+    print(f"Test passed -----> SanketMASTUser")
+
     #Get with VachanUser
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['VachanUser']['token']
     for num in range(4):
@@ -857,6 +988,36 @@ def contetapi_get_accessrule_checks_app_userroles(contenttype, UNIT_URL, data , 
                 assert response.status_code == 403
                 assert response.json()["error"] == "Permission Denied"
     print(f"Test passed -----> AG ADMIN")
+
+    #Get with SanketMASTAdmin
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    for num in range(4):
+        headers_auth['app'] = Apps[num]
+        if bible:
+            response1 = client.get(UNIT_URL+sourcename_list[2]+'/books',headers=headers_auth)
+            response2 = client.get(UNIT_URL+sourcename_list[2]+'/versification',headers=headers_auth)
+            response3 = client.get(UNIT_URL+sourcename_list[2]+'/verses',headers=headers_auth)
+            if headers_auth['app'] == VACHAN or headers_auth['app'] == AG\
+                or headers_auth['app'] == API:
+                assert response1.status_code == 200
+                assert response2.status_code == 200
+                assert response3.status_code == 200
+            else:
+                assert response1.status_code == 403
+                assert response1.json()["error"] == "Permission Denied"
+                assert response2.status_code == 403
+                assert response2.json()["error"] == "Permission Denied"
+                assert response3.status_code == 403
+                assert response3.json()["error"] == "Permission Denied"
+        else:
+            response = client.get(UNIT_URL+sourcename_list[2],headers=headers_auth)
+            if headers_auth['app'] == VACHAN or headers_auth['app'] == AG\
+                or headers_auth['app'] == API:
+                assert response.status_code == 200
+            else:    
+                assert response.status_code == 403
+                assert response.json()["error"] == "Permission Denied"
+    print(f"Test passed -----> SanketMASTAdmin")
 
     #Get with SuperAdmin
     headers_auth['Authorization'] = SA_TOKEN
@@ -1016,6 +1177,25 @@ def contetapi_get_accessrule_checks_app_userroles_gql(contenttype, content_qry, 
                 assert "errors" in response
         print(f"Test passed -----> AG USER")
 
+        #Get with SanketMASTUser
+        headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
+        for num in range(4):
+            headers_auth['app'] = Apps[num]
+            if bible:
+                response = gql_request(query=test_data["books"]["get_query"],variables=test_data["get_var"],
+                    headers=headers_auth)
+                assert "errors" in response
+                response = gql_request(query=test_data["versification"]["get_query"],variables=test_data["get_var"],
+                    headers=headers_auth)
+                assert "errors" in response
+                response = gql_request(query=test_data["verses"]["get_query"],variables=test_data["get_var"],
+                    headers=headers_auth)
+                assert "errors" in response
+            else:
+                response = gql_request(query=test_data["get_query"],variables=test_data["get_var"],headers=headers_auth)
+                assert "errors" in response
+        print(f"Test passed -----> SanketMASTUser")
+
         #Get with VachanUser
         headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['VachanUser']['token']
         for num in range(4):
@@ -1106,6 +1286,27 @@ def contetapi_get_accessrule_checks_app_userroles_gql(contenttype, content_qry, 
                     headers=headers_auth)
                 assert "errors" in response
         print(f"Test passed -----> AG ADMIN")
+
+        #Get with SannketMASTAdmin
+        headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SannketMASTAdmin']['token']
+        for num in range(4):
+            headers_auth['app'] = Apps[num]
+            if bible:
+                response = gql_request(query=test_data["books"]["get_query"],variables=test_data["get_var"],
+                    headers=headers_auth)
+                assert "errors" in response
+                response = gql_request(query=test_data["versification"]["get_query"],variables=test_data["get_var"],
+                    headers=headers_auth)
+                assert "errors" in response
+                response = gql_request(query=test_data["verses"]["get_query"],variables=test_data["get_var"],
+                    headers=headers_auth)
+                assert "errors" in response
+                pass
+            else:
+                response = gql_request(query= test_data["get_query"], variables=test_data["get_var"],
+                    headers=headers_auth)
+                assert "errors" in response
+        print(f"Test passed -----> SannketMASTAdmin")
 
         #Get with SuperAdmin
         headers_auth['Authorization'] = SA_TOKEN
@@ -1232,6 +1433,37 @@ def contetapi_get_accessrule_checks_app_userroles_gql(contenttype, content_qry, 
                 assert "errors" in response      
     print(f"Test passed -----> AG USER")
 
+    #Get with SanketMASTUser
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
+    for num in range(4):
+        headers_auth['app'] = Apps[num]
+        if bible:
+            response1 = gql_request(query=test_data["books"]["get_query"],variables=test_data["get_var"],
+                    headers=headers_auth)
+            response2 = gql_request(query=test_data["versification"]["get_query"],variables=test_data["get_var"],
+                    headers=headers_auth)
+            response3 = gql_request(query=test_data["verses"]["get_query"],variables=test_data["get_var"],
+                    headers=headers_auth)
+            if headers_auth['app'] == API or headers_auth['app'] == VACHAN\
+                or headers_auth['app'] == AG:
+                assert not  "errors" in response1
+                assert not "errors" in response2
+                assert not "errors" in response3
+            else:
+                assert "errors" in response1
+                assert "errors" in response2
+                assert "errors" in response3
+        else:
+            response = gql_request(query= test_data["get_query"], variables=test_data["get_var"],
+                    headers=headers_auth)
+            if headers_auth['app'] == API or headers_auth['app'] == VACHAN\
+                or headers_auth['app'] == AG:
+                assert not "errors" in response
+                assert len(response["data"]) > 0
+            else:
+                assert "errors" in response      
+    print(f"Test passed -----> SanketMASTUser")
+
     #Get with VachanUser
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['VachanUser']['token']
     for num in range(4):
@@ -1352,6 +1584,37 @@ def contetapi_get_accessrule_checks_app_userroles_gql(contenttype, content_qry, 
                 assert "errors" in response              
     print(f"Test passed -----> AG ADMIN")
 
+    #Get with SanketMASTAdmin
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    for num in range(4):
+        headers_auth['app'] = Apps[num]
+        if bible:
+            response1 = gql_request(query=test_data["books"]["get_query"],variables=test_data["get_var"],
+                    headers=headers_auth)
+            response2 = gql_request(query=test_data["versification"]["get_query"],variables=test_data["get_var"],
+                    headers=headers_auth)
+            response3 = gql_request(query=test_data["verses"]["get_query"],variables=test_data["get_var"],
+                    headers=headers_auth)
+            if headers_auth['app'] == API or headers_auth['app'] == VACHAN\
+                or headers_auth['app'] == AG:
+                assert not  "errors" in response1
+                assert not "errors" in response2
+                assert not "errors" in response3
+            else:
+                assert "errors" in response1
+                assert "errors" in response2
+                assert "errors" in response3
+        else:
+            response = gql_request(query= test_data["get_query"], variables=test_data["get_var"],
+                    headers=headers_auth)
+            if headers_auth['app'] == API or headers_auth['app'] == VACHAN\
+                or headers_auth['app'] == AG:
+                assert not "errors" in response
+                assert len(response["data"]) > 0
+            else:
+                assert "errors" in response              
+    print(f"Test passed -----> SanketMASTAdmin")
+
     #Get with SuperAdmin
     headers_auth['Authorization'] = SA_TOKEN
     for num in range(4):
@@ -1465,6 +1728,37 @@ def contetapi_get_accessrule_checks_app_userroles_gql(contenttype, content_qry, 
             else:
                 assert "errors" in response              
     print(f"Test passed -----> AG USER")
+
+    #Get with SanketMASTUser
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
+    for num in range(4):
+        headers_auth['app'] = Apps[num]
+        if bible:
+            response1 = gql_request(query=test_data["books"]["get_query"],variables=test_data["get_var"],
+                    headers=headers_auth)
+            response2 = gql_request(query=test_data["versification"]["get_query"],variables=test_data["get_var"],
+                    headers=headers_auth)
+            response3 = gql_request(query=test_data["verses"]["get_query"],variables=test_data["get_var"],
+                    headers=headers_auth)
+            if headers_auth['app'] == VACHAN or headers_auth['app'] == AG\
+                or headers_auth['app'] == API:
+                assert not  "errors" in response1
+                assert not "errors" in response2
+                assert not "errors" in response3
+            else:
+                assert "errors" in response1
+                assert "errors" in response2
+                assert "errors" in response3
+        else:
+            response = gql_request(query= test_data["get_query"], variables=test_data["get_var"],
+                    headers=headers_auth)
+            if headers_auth['app'] == VACHAN or headers_auth['app'] == AG\
+                or headers_auth['app'] == API:
+                assert not "errors" in response
+                assert len(response["data"]) > 0
+            else:
+                assert "errors" in response              
+    print(f"Test passed -----> SanketMASTUser")
 
     #Get with VachanUser
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['VachanUser']['token']
@@ -1585,6 +1879,37 @@ def contetapi_get_accessrule_checks_app_userroles_gql(contenttype, content_qry, 
             else:
                 assert "errors" in response     
     print(f"Test passed -----> AG ADMIN")
+
+    #Get with SanketMASTAdmin
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    for num in range(4):
+        headers_auth['app'] = Apps[num]
+        if bible:
+            response1 = gql_request(query=test_data["books"]["get_query"],variables=test_data["get_var"],
+                    headers=headers_auth)
+            response2 = gql_request(query=test_data["versification"]["get_query"],variables=test_data["get_var"],
+                    headers=headers_auth)
+            response3 = gql_request(query=test_data["verses"]["get_query"],variables=test_data["get_var"],
+                    headers=headers_auth)
+            if headers_auth['app'] == VACHAN or headers_auth['app'] == AG\
+                or headers_auth['app'] == API:
+                assert not  "errors" in response1
+                assert not "errors" in response2
+                assert not "errors" in response3
+            else:
+                assert "errors" in response1
+                assert "errors" in response2
+                assert "errors" in response3
+        else:
+            response = gql_request(query= test_data["get_query"], variables=test_data["get_var"],
+                    headers=headers_auth)
+            if headers_auth['app'] == VACHAN or headers_auth['app'] == AG\
+                or headers_auth['app'] == API:
+                assert not "errors" in response
+                assert len(response["data"]) > 0
+            else:
+                assert "errors" in response     
+    print(f"Test passed -----> SanketMASTAdmin")
 
     #Get with SuperAdmin
     headers_auth['Authorization'] = SA_TOKEN

--- a/app/test/conftest.py
+++ b/app/test/conftest.py
@@ -49,6 +49,15 @@ initial_test_users = {
                 "test_user_id": "",
                 "app" : schema_auth.App.AG.value
             },
+            "SanketMASTAdmin": {
+                "user_email": "smadmintest@mail.test",
+                "password": "passwordtest@1",
+                "firstname": "SanketMAST",
+                "lastname": "Admin",
+                "token":"",
+                "test_user_id": "",
+                "app" : schema_auth.App.SMAST.value
+            },
             "BcsDev":{
                 "user_email": "bcsdevtest@mail.test",
                 "password": "passwordtest@1",
@@ -66,6 +75,15 @@ initial_test_users = {
                 "token":"",
                 "test_user_id": "",
                 "app" : schema_auth.App.AG.value
+            },
+            "SanketMASTUser":{
+                "user_email": "smtest@mail.test",
+                "password": "passwordtest@1",
+                "firstname": "SanketMAST",
+                "lastname": "User",
+                "token":"",
+                "test_user_id": "",
+                "app" : schema_auth.App.SMAST.value
             },
             "VachanUser":{ 
                 "user_email": "vachantest@mail.test",
@@ -111,6 +129,15 @@ initial_test_users = {
                 "token":"",
                 "test_user_id": "",
                 "app" : schema_auth.App.AG.value
+            },
+            "SanketMASTUser2":{
+                "user_email": "smtest2@mail.test",
+                "password": "passwordtest@1",
+                "firstname": "SanketMAST",
+                "lastname": "User Two",
+                "token":"",
+                "test_user_id": "",
+                "app" : schema_auth.App.SMAST.value
             }
         }
 

--- a/app/test/conftest.py
+++ b/app/test/conftest.py
@@ -171,6 +171,13 @@ def create_user_session_run_at_start():
         assert response.status_code == 201
         assert response.json()["role_list"] == \
             [schema_auth.AdminRoles.AGUSER.value, schema_auth.AdminRoles.AGADMIN.value]
+        #SanketMASTAdmin
+        role_user_id = initial_test_users["SanketMASTAdmin"]["test_user_id"]
+        role_list = [schema_auth.AdminRoles.SMASTADMIN.value]
+        response = assign_roles(super_data,role_user_id,role_list)
+        assert response.status_code == 201
+        assert response.json()["role_list"] == \
+            [schema_auth.AdminRoles.SMASTUSER.value, schema_auth.AdminRoles.SMASTADMIN.value]
         #VachanAdmin
         role_user_id = initial_test_users["VachanAdmin"]["test_user_id"]
         role_list = [schema_auth.AdminRoles.VACHANADMIN.value]

--- a/app/test/test_smast_projects.py
+++ b/app/test/test_smast_projects.py
@@ -1,4 +1,4 @@
-'''Test cases for Agmt projects related APIs'''
+'''Test cases for SanketMAST projects related APIs'''
 from . import client
 from . import assert_input_validation_error, assert_not_available_content
 from . import check_default_get
@@ -12,10 +12,10 @@ UNIT_URL = '/v2/translation/projects'
 USER_URL = '/v2/translation/project/user'
 SENTENCE_URL = '/v2/translation/project/sentences'
 RESTORE_URL = '/v2/restore'
-headers = {"contentType": "application/json", "accept": "application/json", "app":"Autographa"}
+headers = {"contentType": "application/json", "accept": "application/json", "app":"SanketMAST"}
 headers_auth = {"contentType": "application/json",
                 "accept": "application/json",
-                "app":"Autographa"
+                "app":"SanketMAST"
             }
 
 bible_books = {
@@ -56,9 +56,9 @@ def check_post(data, auth_token=None):
     '''creates a projects'''
     headers_auth = {"contentType": "application/json",
                 "accept": "application/json",
-                "app":"Autographa"}
+                "app":"SanketMAST"}
     if not auth_token:
-        headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+        headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     else:
         headers_auth['Authorization'] = "Bearer"+" "+auth_token
     response = client.post(UNIT_URL, headers=headers_auth, json=data)
@@ -66,7 +66,7 @@ def check_post(data, auth_token=None):
 
 def test_default_post_put_get():
     '''Positive test to create a project'''
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     resp = client.get(UNIT_URL+'?project_name=Test project 1',headers=headers_auth)
     assert_not_available_content(resp)
 
@@ -307,7 +307,7 @@ def test_put_invalid():
 
 def check_project_user(project_name, user_id, role=None, status=None, metadata = None):
     '''Make sure the user is in project and if specified, check for other values'''
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     response = client.get(UNIT_URL+'?project_name='+project_name,headers=headers_auth)
     found_user = False
     found_owner = False
@@ -344,8 +344,8 @@ def test_add_user():
     assert response.status_code == 404
     assert response.json()['error'] == 'Requested Content Not Available'
     #exising user
-    new_user_id = initial_test_users['AgUser']['test_user_id']
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    new_user_id = initial_test_users['SanketMASTUser']['test_user_id']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     response = client.post(USER_URL+'?project_id='+str(new_project['projectId'])+
         '&user_id='+str(new_user_id),headers=headers_auth)
     assert response.status_code == 201
@@ -401,7 +401,7 @@ def test_update_user():
     resp = check_post(project_data)
     assert resp.json()['message'] == "Project created successfully"
     new_project = resp.json()['data']
-    new_user_id = initial_test_users['AgUser']['test_user_id']
+    new_user_id = initial_test_users['SanketMASTUser']['test_user_id']
 
     resp = client.post(USER_URL+'?project_id='+str(new_project['projectId'])+
         '&user_id='+str(new_user_id),headers=headers_auth)
@@ -448,7 +448,7 @@ def test_update_user_invlaid():
     resp = check_post(project_data)
     assert resp.json()['message'] == "Project created successfully"
     new_project = resp.json()['data']
-    new_user_id = initial_test_users['AgUser']['test_user_id']
+    new_user_id = initial_test_users['SanketMASTUser']['test_user_id']
 
     resp = client.post(USER_URL+'?project_id='+str(new_project['projectId'])+
         '&user_id='+str(new_user_id),headers=headers_auth)
@@ -572,15 +572,15 @@ def test_agmt_projects_access_rule():
     response = client.post(UNIT_URL, headers=headers, json=post_data)
     assert response.status_code == 401
     assert 'error' in response.json()
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
     assert response.status_code == 201
     assert response.json()['message'] == "Project created successfully"
     project1_id = response.json()['data']['projectId']
 
-    #create from app other than Autographa
+    #create from app other than SanketMAST
     post_data["projectName"] = "Test project 2"
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     headers_auth["app"] = "API-user"
     response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
     assert response.status_code == 403
@@ -598,7 +598,7 @@ def test_agmt_projects_access_rule():
 
     #create project by not allowed users
     post_data["projectName"] = "Test project 5"
-    headers_auth["app"] = "Autographa"
+    headers_auth["app"] = "SanketMAST"
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['BcsDev']['token']
     response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
     assert response.status_code == 403
@@ -627,7 +627,7 @@ def test_agmt_projects_access_rule():
 
     #create with AGUser and SA
     post_data["projectName"] = "Test project 6"
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
     response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
     assert response.status_code == 201
     assert response.json()['message'] == "Project created successfully"
@@ -645,18 +645,18 @@ def test_agmt_projects_access_rule():
     "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
     #update with Owner of project
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
     response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
     assert response2.status_code == 201
     assert response2.json()['message'] == "Project updated successfully"
     updated_project = response2.json()['data']
     assert updated_project['metaData']['books'] == ['mat', 'mrk']
 
-    #aguser project can be updated by super admin and Ag admin
+    #aguser project can be updated by super admin and SanketMAST admin
     put_data = {
         "projectId":project6_id,
         "projectName":"New name for old project6"}
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
     assert response2.status_code == 201
     assert response2.json()['message'] == "Project updated successfully"
@@ -670,15 +670,15 @@ def test_agmt_projects_access_rule():
 
     #update project with not Owner
     put_data["projectId"] = project7_id
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
     response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
     assert response2.status_code == 403
     assert response2.json()['error'] == 'Permission Denied'
 
     #project user create
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
-    new_user_id = initial_test_users['AgUser']['test_user_id']
-    #add user from another app than Autographa
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    new_user_id = initial_test_users['SanketMASTUser']['test_user_id']
+    #add user from another app than SanketMAST
     headers_auth["app"] = "VachanAdmin"
     response = client.post(USER_URL+'?project_id='+str(project1_id)+
         '&user_id='+str(new_user_id),headers=headers_auth)
@@ -695,14 +695,14 @@ def test_agmt_projects_access_rule():
     assert response.status_code == 403
     assert response.json()['error'] == 'Permission Denied'
     #add user by not owner
-    headers_auth["app"] = "Autographa"
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
+    headers_auth["app"] = "SanketMAST"
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
     response = client.post(USER_URL+'?project_id='+str(project1_id)+
         '&user_id='+str(new_user_id),headers=headers_auth)
     assert response.status_code == 403
     assert response.json()['error'] == 'Permission Denied'
     #add from Autograpaha by allowed user
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     post_data["projectName"] = "Test project 8"
     response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
     assert response.status_code == 201
@@ -720,7 +720,7 @@ def test_agmt_projects_access_rule():
     assert data['active']
 
     #update user with not owner
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
     update_data = {
         "project_id": project8_id,
         "userId": new_user_id
@@ -733,7 +733,7 @@ def test_agmt_projects_access_rule():
     assert response3.json()['error'] == 'Permission Denied'
     #update with owner
     post_data['projectName'] = 'Test project 1'
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     response3 = client.put(USER_URL, headers=headers_auth, json=update_data)
     assert response3.status_code == 201
     assert response3.json()['message'] == "User updated in project successfully"
@@ -746,21 +746,21 @@ def test_get_project_access_rules():
     "sourceLanguageCode": "hi",
     "targetLanguageCode": "ml"
     }
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
     assert response.status_code == 201
     assert response.json()['message'] == "Project created successfully"
     project1_id = response.json()['data']['projectId']
 
     post_data["projectName"] = "Test project 2"
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
     response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
     assert response.status_code == 201
     assert response.json()['message'] == "Project created successfully"
     project2_id = response.json()['data']['projectId']
 
     post_data["projectName"] = "Test project 3"
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
     response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
     assert response.status_code == 201
     assert response.json()['message'] == "Project created successfully"
@@ -776,7 +776,7 @@ def test_get_project_access_rules():
     test_SA_token = response.json()["token"]
 
     #get project from apps other than autographa
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     headers_auth["app"] = "API-user"
     response = client.get(UNIT_URL,headers=headers_auth)
     assert response.status_code == 403
@@ -790,8 +790,8 @@ def test_get_project_access_rules():
     assert response.status_code == 403
     assert response.json()['error'] == 'Permission Denied'
 
-    #get project from Autographa with not allowed users get empty result
-    headers_auth["app"] = "Autographa"
+    #get project from SanketMAST with not allowed users get empty result
+    headers_auth["app"] = "SanketMAST"
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['VachanAdmin']['token']
     response = client.get(UNIT_URL,headers=headers_auth)
     assert len(response.json()) == 0
@@ -802,8 +802,8 @@ def test_get_project_access_rules():
     response = client.get(UNIT_URL,headers=headers_auth)
     assert len(response.json()) == 0
 
-    #get all project by SA , AgAdmin, Bcs internal dev
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    #get all project by SA , SanketMASTAdmin, Bcs internal dev
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     response = client.get(UNIT_URL,headers=headers_auth)
     assert len(response.json()) >= 3
 
@@ -815,12 +815,12 @@ def test_get_project_access_rules():
     response = client.get(UNIT_URL,headers=headers_auth)
     assert len(response.json()) >= 3
 
-    #get project by project owner Aguser only get owner project
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
+    #get project by project owner SanketMASTuser only get owner project
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
     response = client.get(UNIT_URL,headers=headers_auth)
     assert len(response.json()) >= 2
 
-    #create project by SA and add Aguser as member to the project
+    #create project by SA and add SanketMASTuser as member to the project
     post_data["projectName"] = 'Test project 4'
     headers_auth['Authorization'] = "Bearer"+" "+ test_SA_token
     response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
@@ -828,7 +828,7 @@ def test_get_project_access_rules():
     assert response.json()['message'] == "Project created successfully"
     project4_id = response.json()['data']['projectId']
 
-    new_user_id = initial_test_users['AgUser']['test_user_id']
+    new_user_id = initial_test_users['SanketMASTUser']['test_user_id']
     response = client.post(USER_URL+'?project_id='+str(project4_id)+
         '&user_id='+str(new_user_id),headers=headers_auth)
     assert response.status_code == 201
@@ -840,24 +840,24 @@ def test_get_project_access_rules():
     assert data['active']
 
     #get after add as member
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
     response = client.get(UNIT_URL+"?user_id="+new_user_id,headers=headers_auth)
     assert len(response.json()) >= 3
     for proj in response.json():
         assert proj['projectName'] in ["Test project 4","Test project 3","Test project 2"]
 
-   #A new Aguser requesting for all projecrts
+   #A new SanketMASTuser requesting for all projecrts
     # test_ag_user_data = {
     #     "email": "testaguser@test.com",
     #     "password": "passwordag@1"
     # }
-    # response = register(test_ag_user_data, apptype='Autographa')
+    # response = register(test_ag_user_data, apptype='SanketMAST')
     # ag_user_id = [response.json()["registered_details"]["id"]]
     # ag_user_token = response.json()["token"]
 
     #get projects where user have no projects result is []
-    headers_auth["app"] = "Autographa"
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser2']['token']
+    headers_auth["app"] = "SanketMAST"
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser2']['token']
     # headers_auth['Authorization'] = "Bearer"+" "+ag_user_token
     response = client.get(UNIT_URL,headers=headers_auth)
     assert len(response.json()) == 0
@@ -866,7 +866,7 @@ def test_get_project_access_rules():
 
 def test_create_n_update_times():
     '''Test to ensure created time and last updated time are included in project GET response'''
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     resp = client.get(UNIT_URL+'?project_name=Test project 1',headers=headers_auth)
     assert_not_available_content(resp)
 
@@ -910,7 +910,7 @@ def test_delete_project():
         "sourceLanguageCode": "hi",
         "targetLanguageCode": "ml"
     }
-    resp = check_post(project_data, auth_token=initial_test_users['AgAdmin']['token'])
+    resp = check_post(project_data, auth_token=initial_test_users['SanketMASTAdmin']['token'])
     assert resp.status_code == 201
     assert resp.json()['message'] == "Project created successfully"
     new_project = resp.json()['data']
@@ -918,7 +918,7 @@ def test_delete_project():
     assert_positive_get(new_project)
 
     # fetch project
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     get_response = client.get(UNIT_URL,headers=headers_auth)
     assert len(get_response.json()) >= 1
     found_project = False
@@ -940,7 +940,7 @@ def test_delete_project():
 
     # deleting non existing  project
     invalid_project_id = 9999
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     resp = client.delete(UNIT_URL+'?project_id='+str(invalid_project_id),headers=headers_auth)
     assert resp.status_code == 404
     assert resp.json()['details'] == f"Project with id {invalid_project_id} not found"
@@ -952,8 +952,8 @@ def test_delete_project():
         assert response.status_code == 403
         assert response.json()['error'] == 'Permission Denied'
 
-    # Delete as AgAdmin- Positive test
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    # Delete as SanketMASTAdmin- Positive test
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     resp = client.delete(UNIT_URL+'?project_id='+str(project_id),headers=headers_auth)
     assert resp.status_code == 201
     assert "successfull" in resp.json()['message']
@@ -962,9 +962,9 @@ def test_delete_project():
     resp = client.get(UNIT_URL+'?project_name=Test project 1',headers=headers_auth)
     assert_not_available_content(resp)
 
-    #Create and Delete Project with AgUser - Positive Test
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
-    post_resp_aguser = check_post(project_data, auth_token=initial_test_users['AgUser']['token'])
+    #Create and Delete Project with SanketMASTUser - Positive Test
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
+    post_resp_aguser = check_post(project_data, auth_token=initial_test_users['SanketMASTUser']['token'])
     assert post_resp_aguser.status_code == 201
     #Ensure presence of created project
     get_response = client.get(UNIT_URL,headers=headers_auth)
@@ -1028,14 +1028,14 @@ def test_restore_project():
         "sourceLanguageCode": "hi",
         "targetLanguageCode": "ml"
     }
-    post_resp= check_post(project_data, auth_token=initial_test_users['AgAdmin']['token'])
+    post_resp= check_post(project_data, auth_token=initial_test_users['SanketMASTAdmin']['token'])
     assert post_resp.status_code == 201
 
     #Get project Id
     project_id = post_resp.json()['data']['projectId']
 
     #Delete
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     delete_resp= client.delete(UNIT_URL+'?project_id='+str(project_id),headers=headers_auth)
     assert delete_resp.status_code == 201
     #Ensure deleted project is not present
@@ -1051,8 +1051,8 @@ def test_restore_project():
     assert response.status_code == 401
     assert response.json()['error'] == 'Authentication Error'
 
-    #Restore project with other API user,VachanAdmin,AgAdmin,AgUser,VachanUser,BcsDev and APIUSer2 - Negative Test
-    for user in ['APIUser','VachanAdmin','AgAdmin','AgUser','VachanUser','BcsDev','APIUser2']:
+    #Restore project with other API user,VachanAdmin,SanketMASTAdmin,SanketMASTUser,VachanUser,BcsDev and APIUSer2 - Negative Test
+    for user in ['APIUser','VachanAdmin','SanketMASTAdmin','SanketMASTUser','VachanUser','BcsDev','APIUser2']:
         headers_auth['Authorization'] = "Bearer"+" "+initial_test_users[user]['token']
         response = client.put(RESTORE_URL, headers=headers_auth, json=data)
         assert response.status_code == 403
@@ -1104,12 +1104,12 @@ def test_delete_user():
         "sourceLanguageCode": "hi",
         "targetLanguageCode": "ml"
     }
-    resp = check_post(project_data, auth_token=initial_test_users['AgAdmin']['token'])
+    resp = check_post(project_data, auth_token=initial_test_users['SanketMASTAdmin']['token'])
     assert resp.json()['message'] == "Project created successfully"
     new_project = resp.json()['data']
-    new_user_id = initial_test_users['AgUser']['test_user_id']
+    new_user_id = initial_test_users['SanketMASTUser']['test_user_id']
 
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     resp = client.post(USER_URL+'?project_id='+str(new_project['projectId'])+
         '&user_id='+str(new_user_id),headers=headers_auth)
     assert resp.json()['message'] == "User added to project successfully"
@@ -1125,8 +1125,8 @@ def test_delete_user():
     check_project_user(project_data['projectName'], new_user_id, role='projectMember')
 
     # deleting non existing user
-    second_user_id = initial_test_users['AgUser2']['test_user_id']
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    second_user_id = initial_test_users['SanketMASTUser2']['test_user_id']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     resp = client.delete(USER_URL+'?project_id='+str(new_project['projectId'])+
         '&user_id='+str(second_user_id),headers=headers_auth)
     assert resp.status_code == 404
@@ -1138,8 +1138,8 @@ def test_delete_user():
     check_project_user(project_data['projectName'], second_user_id, role='projectMember')
 
     #  as non-owner user
-    user_id = initial_test_users['AgUser2']['test_user_id']
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
+    user_id = initial_test_users['SanketMASTUser2']['test_user_id']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
     resp = client.delete(USER_URL+'?project_id='+str(new_project['projectId'])+
         '&user_id='+str(user_id),headers=headers_auth)
     assert resp.status_code == 403
@@ -1147,8 +1147,8 @@ def test_delete_user():
     check_project_user(project_data['projectName'], user_id, role='projectMember')
 
     # as same user
-    user_id = initial_test_users['AgAdmin']['test_user_id']
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    user_id = initial_test_users['SanketMASTAdmin']['test_user_id']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     resp = client.delete(USER_URL+'?project_id='+str(new_project['projectId'])+
         '&user_id='+str(user_id),headers=headers_auth)
     assert resp.status_code == 403
@@ -1156,8 +1156,8 @@ def test_delete_user():
     check_project_user(project_data['projectName'], user_id, role='projectOwner')
 
     # as project owner - Positive test
-    user_id = initial_test_users['AgUser2']['test_user_id']
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    user_id = initial_test_users['SanketMASTUser2']['test_user_id']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     resp = client.delete(USER_URL+'?project_id='+str(new_project['projectId'])+
         '&user_id='+str(user_id),headers=headers_auth)
     assert resp.status_code == 201
@@ -1184,14 +1184,14 @@ def test_restore_user():
         "sourceLanguageCode": "hi",
         "targetLanguageCode": "ml"
     }
-    resp = check_post(project_data, auth_token=initial_test_users['AgAdmin']['token'])
+    resp = check_post(project_data, auth_token=initial_test_users['SanketMASTAdmin']['token'])
     assert resp.json()['message'] == "Project created successfully"
     #  Get project Id
     project_id = resp.json()['data']['projectId']
     new_project = resp.json()['data']
-    user_id = initial_test_users['AgUser']['test_user_id']
+    user_id = initial_test_users['SanketMASTUser']['test_user_id']
 
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     resp = client.post(USER_URL+'?project_id='+str(new_project['projectId'])+
         '&user_id='+str(user_id),headers=headers_auth)
     assert resp.json()['message'] == "User added to project successfully"
@@ -1200,8 +1200,8 @@ def test_restore_user():
     check_project_user(project_data['projectName'], user_id, role='projectMember')
     
     #Delete
-    # user_id = initial_test_users['AgUser']['test_user_id']
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    # user_id = initial_test_users['SanketMASTUser']['test_user_id']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     delete_resp = client.delete(USER_URL+'?project_id='+str(new_project['projectId'])+
         '&user_id='+str(user_id),headers=headers_auth)
     assert delete_resp.status_code == 201
@@ -1230,8 +1230,8 @@ def test_restore_user():
     assert response.status_code == 401
     assert response.json()['error'] == 'Authentication Error'
 
-    #Restore project user with other API user,VachanAdmin,AgAdmin,AgUser,VachanUser,BcsDev and APIUSer2 - Negative Test
-    for user in ['APIUser','VachanAdmin','AgAdmin','AgUser','VachanUser','BcsDev','APIUser2']:
+    #Restore project user with other API user,VachanAdmin,SanketMASTAdmin,SanketMASTUser,VachanUser,BcsDev and APIUSer2 - Negative Test
+    for user in ['APIUser','VachanAdmin','SanketMASTAdmin','SanketMASTUser','VachanUser','BcsDev','APIUser2']:
         headers_auth['Authorization'] = "Bearer"+" "+initial_test_users[user]['token']
         response = client.put(RESTORE_URL, headers=headers_auth, json=data)
         assert response.status_code == 403
@@ -1275,7 +1275,7 @@ def test_bugfix_split_n_merged_verse():
     "sourceLanguageCode": "hi",
     "targetLanguageCode": "ml"
     }
-    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
     assert response.status_code == 201
     assert response.json()['message'] == "Project created successfully"

--- a/app/test/test_smast_translation.py
+++ b/app/test/test_smast_translation.py
@@ -1,0 +1,1074 @@
+'''tests for the translation workflow within SanketMAST projects'''
+
+import re
+from math import ceil, floor
+from . import client
+from . import assert_input_validation_error, assert_not_available_content
+from .test_agmt_projects import bible_books, check_post as add_project
+from .conftest import initial_test_users
+from . test_auth_basic import login,SUPER_PASSWORD,SUPER_USER
+
+
+UNIT_URL = '/v2/translation/project'
+headers = {"contentType": "application/json", "accept": "application/json","app":"SanketMAST"}
+headers_auth = {"contentType": "application/json",
+                "accept": "application/json",
+                "app":"SanketMAST"
+            }
+
+project_data = {
+    "projectName": "Test SanketMAST workflow",
+    "sourceLanguageCode": "hi",
+    "targetLanguageCode": "ml"
+}
+
+sample_stopwords = ["के", "की"]
+
+def assert_positive_get_tokens(item):
+    '''common tests for a token response object'''
+    assert "token" in item
+    assert "occurrences" in item
+    assert len(item['occurrences']) > 0
+    assert "translations" in item
+    for trans in item['translations']:
+        assert isinstance(item['translations'][trans], (int, float))
+    if "metaData" in item and item['metaData'] is not None:
+        assert isinstance(item['metaData'], dict)
+
+def assert_positive_get_sentence(item):
+    '''common test for senstence object'''
+    assert "sentenceId" in item
+    assert "sentence" in item
+    assert isinstance(item['sentence'], str)
+    if "draft" in item:
+        assert isinstance(item['draft'], str)
+        assert "draftMeta" in item
+        assert isinstance(item['draftMeta'], list)
+
+def test_get_tokens():
+    '''Positive tests for tokenization process'''
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    resp = add_project(project_data)
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    # before adding books
+    get_response1 = client.get(UNIT_URL+"/tokens?project_id="+str(project_id),headers=headers_auth)
+    assert_not_available_content(get_response1)
+
+    put_data = {
+        "projectId": project_id,
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
+    }
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    # after adding books
+    #without auth
+    get_response2 = client.get(UNIT_URL+"/tokens?project_id="+str(project_id), headers=headers)
+    assert get_response2.json()['error'] == 'Authentication Error'
+    get_response2 = client.get(UNIT_URL+"/tokens?project_id="+str(project_id),headers=headers)
+    assert get_response2.status_code == 401
+    assert get_response2.json()['error'] == 'Authentication Error'
+    #with auth
+    get_response2 = client.get(UNIT_URL+"/tokens?project_id="+str(project_id),headers=headers_auth)
+    assert get_response2.status_code == 200
+    assert isinstance(get_response2.json(), list)
+    for item in get_response2.json():
+        assert_positive_get_tokens(item)
+
+    # with book filter
+    get_response3 = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+"&books=mat"
+    ,headers=headers_auth)
+    assert get_response3.status_code == 200
+    assert len(get_response3.json()) < len(get_response2.json())
+
+    get_response4 = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+"&books=mrk"
+    ,headers=headers_auth)
+    assert get_response4.status_code == 200
+    all_tokens = [item['token'] for item in get_response3.json() + get_response4.json()]
+    assert len(get_response2.json()) == len(set(all_tokens))
+
+    # with range filter
+    get_response5 = client.get(UNIT_URL+'/tokens?project_id='+str(project_id)+
+        "&sentence_id_range=0&sentence_id_range=10",headers=headers_auth)
+    # print(get_response5.json())
+    assert_not_available_content(get_response5)
+
+    get_response6 = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&sentence_id_range=41000000&sentence_id_range=41999999",headers=headers_auth)
+    assert get_response6.status_code ==200
+    assert get_response6.json() == get_response3.json()
+
+    # with list filter
+    get_response7 = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&sentence_id_list=41000000",headers=headers_auth)
+    assert_not_available_content(get_response7)
+
+    get_response7 = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&sentence_id_list=41001001",headers=headers_auth)
+    assert get_response7.status_code == 200
+    assert 0 < len(get_response7.json()) < 25
+
+    # translation_memory flag
+    get_response8 = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&use_translation_memory=true",headers=headers_auth)
+    assert get_response8.json() == get_response2.json()
+
+    get_response9 = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&use_translation_memory=false",headers=headers_auth)
+    assert get_response9.status_code == 200
+    assert len(get_response9.json()) > 0
+
+    # include_phrases flag
+    get_response10 = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&include_phrases=true",headers=headers_auth)
+    assert get_response10.json() == get_response2.json()
+
+    get_response11 = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&include_phrases=false",headers=headers_auth)
+    assert get_response11.status_code == 200
+    assert len(get_response11.json()) <= len(get_response10.json())
+    for item in get_response11.json():
+        assert " " not in item['token']
+
+    # include_stopwords flag
+    get_response12 = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&include_stopwords=false",headers=headers_auth)
+    assert get_response12.json() == get_response2.json()
+    for item in get_response12.json():
+        assert item['token'] not in sample_stopwords
+
+    get_response13 = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&include_stopwords=True&include_phrases=false",headers=headers_auth)
+    all_tokens = [item['token'] for item in get_response13.json()]
+    assert sample_stopwords[0] in all_tokens
+
+
+def test_tokenization_invalid():
+    '''Negative tests for tokenization'''
+    resp = add_project(project_data)
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    # non existant project
+    response = client.get(UNIT_URL+"/tokens?project_id="+str(project_id+1),headers=headers_auth)
+    assert response.status_code == 404
+    assert response.json()['details'] == "Project with id, %s, not found"%(project_id+1)
+
+    #invalid book
+    response = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+"&books=mmm"
+    ,headers=headers_auth)
+    assert response.status_code == 404
+    assert response.json()['details'] == 'Book, mmm, not in database'
+
+    # only one value for range
+    response = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&sentence_id_range=41000000",headers=headers_auth)
+    assert_input_validation_error(response)
+
+    # incorrect value for range
+    response = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&sentence_id_range=gen&sentence_id_range=num",headers=headers_auth)
+    assert_input_validation_error(response)
+
+    # incorrect value for id
+    response = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&sentence_id_list=first",headers=headers_auth)
+    assert_input_validation_error(response)
+
+    # incorrect value for flags
+    response = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&include_stopwords=Few",headers=headers_auth)
+    assert_input_validation_error(response)
+
+    response = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&include_phrases=10",headers=headers_auth)
+    assert_input_validation_error(response)
+
+    response = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&use_translation_memory=always",headers=headers_auth)
+    assert_input_validation_error(response)
+
+def test_save_translation():
+    '''Positive tests for PUT tokens method'''
+    resp = add_project(project_data)
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    put_data = {
+        "projectId": project_id,
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
+    }
+
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    resp = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&include_stopwords=true",headers=headers_auth)
+    assert resp.status_code == 200
+    all_tokens = resp.json()
+
+    # one occurence
+    post_obj_list = [
+      {
+        "token": all_tokens[0]['token'],
+        "occurrences": [all_tokens[0]["occurrences"][0]],
+        "translation": "test translation"
+      }
+    ]
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id),
+        headers=headers_auth, json=post_obj_list)
+    assert response.status_code == 201
+    assert response.json()['message'] == 'Token translations saved'
+    assert response.json()['data'][0]['draft'].startswith("test translation")
+    assert response.json()['data'][0]['draftMeta'][0][2] == "confirmed"
+    for segment in response.json()['data'][0]['draftMeta'][1:]:
+        assert segment[2] != "confirmed"
+
+    # multiple occurances
+    post_obj_list = [
+      {
+        "token": all_tokens[0]['token'],
+        "occurrences": all_tokens[0]["occurrences"],
+        "translation": "test translation"
+      }
+    ]
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id),
+        headers=headers_auth, json=post_obj_list)
+    assert response.status_code == 201
+    assert response.json()['message'] == 'Token translations saved'
+    for sent in response.json()['data']:
+        assert "test translation" in sent['draft']
+
+    #Without auth
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id),
+    json=post_obj_list, headers=headers)
+    assert response.json()['error'] == 'Authentication Error'
+
+    # all tokens at once
+    post_obj_list = []
+    for item in all_tokens:
+        obj = {
+            "token": item['token'],
+            "occurrences": item["occurrences"],
+            "translation": "test"
+        }
+        post_obj_list.append(obj)
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id),
+        headers=headers_auth, json=post_obj_list)
+    assert response.status_code == 201
+    for sent in response.json()['data']:
+        words = re.findall(r'\w+', sent['draft'])
+        for wrd in words:
+            assert wrd == 'test'
+
+def test_save_translation_invalid():
+    '''Negative tests for PUT tokens method'''
+    resp = add_project(project_data)
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    put_data = {
+        "projectId": project_id,
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
+    }
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    resp = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&include_stopwords=true",headers=headers_auth)
+    assert resp.status_code == 200
+    all_tokens = resp.json()
+
+    # incorrect project id
+    obj = {
+        "token": all_tokens[0]['token'],
+        "occurrences": all_tokens[0]["occurrences"],
+        "translation": "sample translation"
+    }
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id+1),
+        headers=headers_auth, json=[obj])
+    assert response.status_code == 404
+    assert response.json()['details'] == 'Project with id, %s, not present'%(project_id+1)
+
+    # without token
+    obj = {
+        "occurrences": all_tokens[0]["occurrences"],
+        "translation": "sample translation"
+    }
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id+1),
+        headers=headers_auth, json=[obj])
+    assert_input_validation_error(response)
+
+    # without occurences
+    obj = {
+        "token": all_tokens[0]['token'],
+        "translation": "sample translation"
+    }
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id+1),
+        headers=headers_auth, json=[obj])
+    assert_input_validation_error(response)
+
+    # without translation
+    obj = {
+        "token": all_tokens[0]['token'],
+        "occurrences": all_tokens[0]["occurrences"]
+    }
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id+1),
+        headers=headers_auth, json=[obj])
+    assert_input_validation_error(response)
+
+    # incorrect occurences
+    wrong_occur = all_tokens[0]["occurrences"][0]
+    wrong_occur['sentenceId'] = 0
+    obj = {
+        "token": all_tokens[0]['token'],
+        "occurrences": [wrong_occur],
+        "translation": "sample translation"
+    }
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id),
+        headers=headers_auth, json=[obj])
+    assert response.status_code ==404
+    assert response.json()['details'] == "Sentence id, 0, not found for the selected project"
+
+    # wrong token-occurence pair
+    obj = {
+        "token": all_tokens[0]['token'],
+        "occurrences": all_tokens[1]['occurrences'],
+        "translation": "sample translation"
+    }
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id),
+        headers=headers_auth, json=[obj])
+    assert response.status_code == 500
+    assert response.json()['details'] ==\
+         'Token, %s, and its occurence, not matching'%(all_tokens[0]['token'])
+
+def test_drafts():
+    '''End to end test from tokenization to draft generation'''
+    resp = add_project(project_data)
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    put_data = {
+        "projectId": project_id,
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
+    }
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    resp = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&include_stopwords=true",headers=headers_auth)
+    assert resp.status_code == 200
+    all_tokens = resp.json()
+
+    # translate all tokens at once
+    post_obj_list = []
+    for item in all_tokens:
+        obj = {
+            "token": item['token'],
+            "occurrences": item["occurrences"],
+            "translation": "test"
+        }
+        post_obj_list.append(obj)
+    resp = client.put(UNIT_URL+"/tokens?project_id="+str(project_id),
+        headers=headers_auth, json=post_obj_list)
+    assert resp.status_code == 201
+    assert resp.json()['message'] == "Token translations saved"
+
+    response = client.get(UNIT_URL+'/draft?project_id='+str(project_id),headers=headers_auth)
+    assert response.status_code ==200
+    assert isinstance(response.json(), list)
+    assert "\\v 1 test test test" in response.json()[0]
+
+    response = client.get(UNIT_URL+'/draft?project_id='+str(project_id)+
+        "&books=mat",headers=headers_auth)
+    assert len(response.json()) == 1
+    assert "\\id MAT" in response.json()[0]
+
+    #Without Auth
+    response = client.get(UNIT_URL+'/draft?project_id='+str(project_id)+
+        "&books=mat", headers=headers)
+    assert response.json()['error'] == 'Authentication Error'
+    response = client.get(UNIT_URL+'/draft?project_id='+str(project_id)+
+        "&books=mat",headers=headers)
+    assert response.status_code == 401
+    assert response.json()['error'] == 'Authentication Error'
+
+    # To be added: proper tests for alignment json drafts
+    response = client.get(UNIT_URL+'/draft?project_id='+str(project_id)+
+        "&output_format=alignment-json",headers=headers_auth)
+    assert response.status_code == 200
+    assert isinstance(response.json(), dict)
+
+def test_get_token_sentences():
+    '''Check if draft-meta is properly segemneted according to specifed token occurence'''
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    resp = add_project(project_data)
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    put_data = {
+        "projectId": project_id,
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
+    }
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    resp = client.get("/v2/translation/project/tokens?project_id="+str(project_id)
+        ,headers=headers_auth)
+    tokens = resp.json()
+    our_token = tokens[0]['token']
+    occurrences = tokens[0]['occurrences']
+
+    #before translating
+    response = client.put('/v2/translation/project/token-sentences?project_id='+
+        str(project_id)+'&token='+our_token,
+        json=occurrences, headers=headers_auth)
+    assert response.status_code == 200
+    for sent, occur in zip(response.json(), occurrences):
+        assert_positive_get_sentence(sent)
+        found_slice = False
+        if sent['sentenceId'] == occur["sentenceId"]:
+            for meta in sent['draftMeta']:
+                if meta[0] == occur['offset']:
+                    found_slice = True
+        assert found_slice
+
+    post_obj_list = [
+      {
+        "token": our_token,
+        "occurrences": occurrences,
+        "translation": "sample"
+      }
+    ]
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id),
+        headers=headers_auth, json=post_obj_list)
+    assert response.status_code == 201
+    assert response.json()['message'] == 'Token translations saved'
+
+    # after translation
+    response2 = client.put('/v2/translation/project/token-sentences?project_id='+
+        str(project_id)+'&token='+our_token, headers=headers_auth,
+        json=occurrences)
+    assert response2.status_code == 200
+    for sent, occur in zip(response2.json(), occurrences):
+        found_slice = False
+        if sent['sentenceId'] == occur["sentenceId"]:
+            for meta in sent['draftMeta']:
+                if meta[0] == occur['offset']:
+                    found_slice = True
+                    assert meta[2] == "confirmed"
+        assert found_slice
+
+    #Without auth
+    response2 = client.put('/v2/translation/project/token-sentences?project_id='+
+        str(project_id)+'&token='+our_token, json=occurrences)
+    assert response2.json()['error'] == 'Permission Denied'
+
+def test_get_sentence():
+    '''Positive test for agmt sentence/draft fetch API'''
+    resp = add_project(project_data)
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    # before adding books
+    response = client.get(UNIT_URL+"/sentences?project_id="+str(project_id)
+    ,headers=headers_auth)
+    assert_not_available_content(response)
+
+    put_data = {
+        "projectId": project_id,
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
+    }
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    # before translation
+    response = client.get(UNIT_URL+"/sentences?project_id="+str(project_id)+
+        "&with_draft=True",headers=headers_auth)
+    assert response.status_code ==200
+    assert len(response.json()) > 1
+    for item in response.json():
+        assert_positive_get_sentence(item)
+        assert item['sentence'] != ""
+        assert item['draft'] == ""
+
+
+    # translate all tokens at once
+    resp = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&include_stopwords=true",headers=headers_auth)
+    assert resp.status_code == 200
+    all_tokens = resp.json()
+    post_obj_list = []
+    for item in all_tokens:
+        obj = {
+            "token": item['token'],
+            "occurrences": item["occurrences"],
+            "translation": "test"
+        }
+        post_obj_list.append(obj)
+    resp = client.put(UNIT_URL+"/tokens?project_id="+str(project_id),
+        headers=headers_auth, json=post_obj_list)
+    assert resp.status_code == 201
+    assert resp.json()['message'] == "Token translations saved"
+
+    # after token translation
+    response = client.get(UNIT_URL+"/sentences?project_id="+str(project_id)+
+        "&with_draft=True",headers=headers_auth)
+    assert response.status_code ==200
+    for item in response.json():
+        assert_positive_get_sentence(item)
+        words = re.findall(r'\w+',item['draft'])
+        for wrd in words:
+            assert wrd == "test"
+
+    #without auth        
+    response = client.get(UNIT_URL+"/sentences?project_id="+str(project_id)+
+        "&with_draft=True", headers=headers)
+    assert response.json()['error'] == 'Authentication Error'
+    response = client.get(UNIT_URL+"/sentences?project_id="+str(project_id)+
+        "&with_draft=True",headers=headers)
+    assert response.status_code == 401
+    assert response.json()['error'] == 'Authentication Error'
+
+    # With only_ids
+    response = client.get(UNIT_URL+"/sentences?project_id="+str(project_id)+
+        "&only_ids=True",headers=headers_auth)
+    assert response.status_code ==200
+    for item in response.json():
+        assert "sentenceId" in item
+        assert "surrogateId" in item
+        assert "sentence" not in item
+        assert "draft" not in item
+        assert "draftMeta" not in item
+
+def test_progress_n_suggestion():
+    '''tests for project progress API of SanketMASTMT'''
+    resp = add_project(project_data)
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    # before adding books
+    response = client.get(UNIT_URL+"/progress?project_id="+str(project_id)
+    ,headers=headers_auth)
+    assert response.status_code ==200
+    assert response.json()['confirmed'] == 0
+    assert response.json()['untranslated'] == 0
+    assert response.json()['suggestion'] == 0
+
+    put_data = {
+        "projectId": project_id,
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
+    }
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    # before translation
+    response = client.get(UNIT_URL+"/progress?project_id="+str(project_id)
+    ,headers=headers_auth)
+    assert response.status_code ==200
+    assert response.json()['confirmed'] == 0
+    assert response.json()['untranslated'] == 1
+    assert response.json()['suggestion'] == 0
+
+    # # Apply suggestions
+    # resp = client.put(UNIT_URL+"/suggestions?project_id="+str(project_id))
+    # assert resp.status_code ==201
+    # found_suggestion = False
+    # [print(sent['draft']) for sent in resp.json()]
+    # for sent in resp.json():
+    #     for meta in sent['draftMeta']:
+    #         if meta[2] == 'suggestion':
+    #             found_suggestion = True
+    #             break
+    # assert found_suggestion
+
+    # # after suggestions
+    # response = client.get(UNIT_URL+"/progress?project_id="+str(project_id))
+    # assert response.status_code ==200
+    # assert response.json()['suggestion'] > 0
+
+    # translate all tokens at once
+    resp = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
+        "&include_stopwords=true",headers=headers_auth)
+    assert resp.status_code == 200
+    all_tokens = resp.json()
+    post_obj_list = []
+    for item in all_tokens:
+        obj = {
+            "token": item['token'],
+            "occurrences": item["occurrences"],
+            "translation": "test"
+        }
+        post_obj_list.append(obj)
+    resp = client.put(UNIT_URL+"/tokens?project_id="+str(project_id),
+        headers=headers_auth, json=post_obj_list)
+    assert resp.status_code == 201
+    assert resp.json()['message'] == "Token translations saved"
+
+    # after token translation
+    response = client.get(UNIT_URL+"/progress?project_id="+str(project_id)
+    ,headers=headers_auth)
+    assert response.status_code ==200
+    assert ceil(response.json()['confirmed']) == 1
+    assert floor(response.json()['untranslated']) == 0
+
+    #Without Auth
+    response = client.get(UNIT_URL+"/progress?project_id="+str(project_id), headers=headers)
+    assert response.json()['error'] == 'Authentication Error'
+    response = client.get(UNIT_URL+"/progress?project_id="+str(project_id)
+    ,headers=headers)
+    assert response.status_code == 401
+    assert response.json()['error'] == 'Authentication Error'
+
+def test_get_versification():
+    '''Positive test for agmt sentence/draft fetch API'''
+    resp = add_project(project_data)
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    # before adding books
+    response = client.get(UNIT_URL+"/versification?project_id="+str(project_id)
+    ,headers=headers_auth)
+    for key in response.json():
+        assert len(response.json()[key]) == 0
+
+    put_data = {
+        "projectId": project_id,
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
+    }
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    response = client.get(UNIT_URL+"/versification?project_id="+str(project_id)
+    ,headers=headers_auth)
+    found_mat = False
+    found_mrk = False
+    for book in response.json()['maxVerses']:
+        if book == "mat":
+            found_mat = True
+        if book == "mrk":
+            found_mrk = True
+    assert found_mat and found_mrk
+
+    #without auth
+    response = client.get(UNIT_URL+"/versification?project_id="+str(project_id), headers=headers)
+    assert response.json()['error'] == 'Authentication Error'
+    #without auth but from SanketMAST
+    response = client.get(UNIT_URL+"/versification?project_id="+str(project_id)
+    ,headers=headers)
+    assert response.status_code == 401
+    assert response.json()['error'] == 'Authentication Error'
+
+#Project translation Access Rules based tests
+def test_agmt_translation_access_rule_app():
+    """project translation related access rule and auth"""
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    #create a project
+    resp = add_project(project_data)
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    put_data = {
+        "projectId": project_id,
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
+    }
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    #get tokens
+    #without auth not from SanketMAST
+    resp = client.get("/v2/translation/project/tokens?project_id="+str(project_id))
+    assert resp.json()['error'] == "Permission Denied"
+    #without auth and from SanketMAST
+    resp = client.get("/v2/translation/project/tokens?project_id="+str(project_id)
+        ,headers=headers)
+    assert resp.status_code == 401
+    assert resp.json()['error'] == 'Authentication Error'
+    #With Auth and From SanketMAST
+    resp = client.get("/v2/translation/project/tokens?project_id="+str(project_id)
+        ,headers=headers_auth)
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+    for item in resp.json():
+        assert_positive_get_tokens(item)
+
+    #Apply token translations PUT
+    all_tokens = resp.json()
+    our_token = all_tokens[0]['token']
+    occurrences = all_tokens[0]['occurrences']
+
+    post_obj_list = [
+      {
+        "token": all_tokens[0]['token'],
+        "occurrences": [all_tokens[0]["occurrences"][0]],
+        "translation": "test translation"
+      }
+    ]
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id),
+        headers=headers_auth, json=post_obj_list)
+    assert response.status_code == 201
+    assert response.json()['message'] == 'Token translations saved'
+    #Wihout Auth from SanketMAST
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id),
+        headers=headers, json=post_obj_list)
+    assert response.json()['error'] == "Authentication Error"
+    #Outside SanketMAST wihtou Auth
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id),
+    json=post_obj_list)
+    assert response.json()['error'] == "Permission Denied"
+
+    #get token translation
+    response = client.get(UNIT_URL+"/token-translations?project_id="+str(project_id)+
+        "&token="+all_tokens[0]['token']+"&sentence_id=41001001&offset=0&offset=4",
+        headers=headers_auth, json=post_obj_list)
+    assert response.status_code == 200
+    assert len(response.json()) > 0
+    #Without Auth from SanketMAST
+    response = client.get(UNIT_URL+"/token-translations?project_id="+str(project_id)+
+        "&token="+all_tokens[0]['token']+"&sentence_id=41001001&offset=0&offset=4",
+        headers=headers, json=post_obj_list)
+    assert response.status_code == 401
+    assert response.json()['error'] == 'Authentication Error'
+    #Without Auth and not from SanketMAST
+    response = client.get(UNIT_URL+"/token-translations?project_id="+str(project_id)+
+        "&token="+all_tokens[0]['token']+"&sentence_id=41001001&offset=0&offset=4",
+        json=post_obj_list)
+    assert response.json()['error'] == "Permission Denied"
+
+    #Get Token Sentences PUT
+    response = client.put('/v2/translation/project/token-sentences?project_id='+
+        str(project_id)+'&token='+our_token,
+        json=occurrences, headers=headers_auth)
+    assert response.status_code == 200
+    #Without Auth and from SanketMAST
+    response = client.put('/v2/translation/project/token-sentences?project_id='+
+        str(project_id)+'&token='+our_token,
+        json=occurrences, headers=headers)
+    assert response.status_code == 401
+    assert response.json()['error'] == "Authentication Error"
+    #Without Auth and not from SanketMAST
+    response = client.put('/v2/translation/project/token-sentences?project_id='+
+        str(project_id)+'&token='+our_token,
+        json=occurrences)
+    assert response.status_code == 403
+    assert response.json()['error'] == "Permission Denied"
+
+    #Get Draft
+    response = client.get(UNIT_URL+'/draft?project_id='+str(project_id)+
+        "&output_format=alignment-json",headers=headers_auth)
+    assert response.status_code == 200
+    #Without Auth and From SanketMAST
+    response = client.get(UNIT_URL+'/draft?project_id='+str(project_id)+
+        "&output_format=alignment-json",headers=headers)
+    assert response.status_code == 401
+    assert response.json()['error'] == 'Authentication Error'
+    #Without Auth and not From SanketMAST
+    response = client.get(UNIT_URL+'/draft?project_id='+str(project_id)+
+        "&output_format=alignment-json")
+    assert response.status_code == 403
+    assert response.json()['error'] == "Permission Denied"
+
+    #Project Source Get
+    response = client.get(UNIT_URL+"/sentences?project_id="+str(project_id)+
+        "&with_draft=True",headers=headers_auth)
+    assert response.status_code ==200
+    #Without Auth and From SanketMAST
+    response = client.get(UNIT_URL+"/sentences?project_id="+str(project_id)+
+        "&with_draft=True",headers=headers)
+    assert response.status_code == 401
+    assert response.json()['error'] == 'Authentication Error'
+    #Without Auth and not From SanketMAST
+    response = client.get(UNIT_URL+"/sentences?project_id="+str(project_id)+
+        "&with_draft=True")
+    assert response.status_code == 403
+    assert response.json()['error'] == "Permission Denied"
+
+    #Project Progress
+    response = client.get(UNIT_URL+"/progress?project_id="+str(project_id),
+    headers=headers_auth)
+    assert response.status_code ==200
+    #Without Auth and From SanketMAST
+    response = client.get(UNIT_URL+"/progress?project_id="+str(project_id),
+    headers=headers)
+    assert response.status_code == 401
+    assert response.json()['error'] == 'Authentication Error'
+    #Without Auth and not From SanketMAST
+    response = client.get(UNIT_URL+"/progress?project_id="+str(project_id))
+    assert response.status_code == 403
+    assert response.json()['error'] == "Permission Denied"
+
+    #Project Versification
+    response = client.get(UNIT_URL+"/versification?project_id="+str(project_id)
+    ,headers=headers_auth)
+    assert response.status_code ==200
+    #Without Auth and From SanketMAST
+    response = client.get(UNIT_URL+"/versification?project_id="+str(project_id)
+    ,headers=headers)
+    assert response.status_code == 401
+    assert response.json()['error'] == 'Authentication Error'
+    #Without Auth and not From SanketMAST
+    response = client.get(UNIT_URL+"/versification?project_id="+str(project_id))
+    assert response.status_code == 403
+    assert response.json()['error'] == "Permission Denied"
+
+def test_data_updated_time():
+    '''Bugfix of issue #563:https://github.com/Bridgeconn/vachan-api/issues/563 '''
+
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+
+    #create an empty project
+    create_project_resp = add_project(project_data)
+    assert create_project_resp.json()['message'] == "Project created successfully"
+    project_id = create_project_resp.json()['data']['projectId']
+    project_name =create_project_resp.json()['data']['projectName']
+    project_create_time = create_project_resp.json()['data']['createTime']
+
+    # Add book into empty project
+    put_data = {
+        "projectId": project_id,
+        "uploadedUSFMs":[bible_books['mat']]
+    }
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    # Get tokens
+    resp = client.get("/v2/translation/project/tokens?project_id="+str(project_id)
+         ,headers=headers_auth)
+
+    # Case 1:PUT Tokens
+    #Apply token translations
+    all_tokens = resp.json()
+    post_obj_list = [
+      {
+        "token": all_tokens[0]['token'],
+        "occurrences": [all_tokens[0]["occurrences"][0]],
+        "translation": "test translation"
+      }
+    ]
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id),
+        headers=headers_auth, json=post_obj_list)
+
+    # Get project details
+    project_url = f"/v2/translation/projects?project_name={project_name}"
+    project_resp = client.get(project_url, headers=headers_auth)
+    project_update_time = project_resp.json()[0]['updateTime']
+    assert not project_create_time == project_update_time
+
+    # Check sentences are added
+    resp = client.get(f"{UNIT_URL}/sentences?project_id={project_id}", headers=headers_auth)
+    sentence_id = resp.json()[0]['sentenceId']
+
+    # Case 2 : PUT Draft
+    put_data = [
+            {"sentenceId":sentence_id,
+             "draft": "കാട്",
+             "draftMeta":[
+                  [ [5,11], [0,4], "confirmed"]
+                ]
+            }
+    ]
+    resp = client.put(f"/v2/translation/project/draft?project_id={project_id}",
+        headers=headers_auth, json=put_data)
+    # Get project details
+    project_resp = client.get(project_url, headers=headers_auth)
+    project_update_time = project_resp.json()[0]['updateTime']
+    assert not project_create_time == project_update_time
+ 
+    #Case 3: Update suggestions
+    resp = client.put(f"/v2/translation/project/suggestions?project_id={project_id}&sentenceIdList={sentence_id}",
+        headers=headers_auth)
+    assert resp.status_code == 201
+     # Get project details
+    project_resp = client.get(project_url, headers=headers_auth)
+    project_update_time = project_resp.json()[0]['updateTime']
+    assert not project_create_time == project_update_time
+
+    # Case 4 : Delete Sentence
+    response = client.delete(f"{UNIT_URL}/sentences?project_id={project_id}&sentence_id={sentence_id}",
+            headers=headers_auth)
+    assert response.status_code == 201
+    assert "successfull" in response.json()['message']
+     # Get project details
+    project_resp = client.get(project_url, headers=headers_auth)
+    project_update_time = project_resp.json()[0]['updateTime']
+    assert not project_create_time == project_update_time
+
+
+#Project translation Access rules based permission
+def test_agmt_translation_access_permissions():
+    """test for access permission to project translation"""
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    #create a project
+    resp = add_project(project_data)
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    put_data = {
+        "projectId": project_id,
+        "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
+    }
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    resp = client.get("/v2/translation/project/tokens?project_id="+str(project_id)
+        ,headers=headers_auth)
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+    for item in resp.json():
+        assert_positive_get_tokens(item)
+
+    #Apply token translations PUT
+    all_tokens = resp.json()
+    our_token = all_tokens[0]['token']
+    occurrences = all_tokens[0]['occurrences']
+
+    post_obj_list = [
+      {
+        "token": all_tokens[0]['token'],
+        "occurrences": [all_tokens[0]["occurrences"][0]],
+        "translation": "test translation"
+      }
+    ]
+
+    #create a SanketMASTUser and add as memeber to a project and SA
+    #Super Admin
+    SA_user_data = {
+            "user_email": SUPER_USER,
+            "password": SUPER_PASSWORD
+        }
+    response = login(SA_user_data)
+    assert response.json()['message'] == "Login Succesfull"
+    test_SA_token = response.json()["token"]
+
+    #PUT Permission in agmt translations
+    #"SuperAdmin", "SanketMASTAdmin", "projectOwner", "projectMember"
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id),
+        headers=headers_auth, json=post_obj_list)
+    assert response.status_code == 201
+    assert response.json()['message'] == 'Token translations saved'
+
+    headers_auth['Authorization'] = "Bearer"+" "+test_SA_token
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id),
+        headers=headers_auth, json=post_obj_list)
+    assert response.status_code == 201
+    assert response.json()['message'] == 'Token translations saved'
+
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser2']['token']
+    #PUT with SanketMASTuser not a member
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id),
+        headers=headers_auth, json=post_obj_list)
+    assert response.status_code == 403
+    assert response.json()['error'] == "Permission Denied"
+
+    response = client.put('/v2/translation/project/token-sentences?project_id='+
+        str(project_id)+'&token='+our_token,
+        json=occurrences, headers=headers_auth)
+    assert response.status_code == 403
+    assert response.json()['error'] == "Permission Denied"
+
+    #Add SanketMASTUser as memeber to projects
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    response = client.post('/v2/translation/project/user'+'?project_id='+str(project_id)+
+        '&user_id='+str(initial_test_users['SanketMASTUser2']["test_user_id"]),headers=headers_auth)
+    assert response.status_code == 201
+    assert response.json()['message'] == "User added to project successfully"
+
+    #After adding as member PUT
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser2']['token']
+    response = client.put(UNIT_URL+"/tokens?project_id="+str(project_id),
+        headers=headers_auth, json=post_obj_list)
+    assert response.status_code == 201
+    print("resp after put token:",resp.json())
+
+    response = client.put('/v2/translation/project/token-sentences?project_id='+
+        str(project_id)+'&token='+our_token,
+        json=occurrences, headers=headers_auth)
+    assert response.status_code == 200
+
+    #GET Permission in agmt translations
+    #"SuperAdmin", "SanketMASTAdmin", "projectOwner", "projectMember", "BcsDeveloper"
+    token_list = []
+    token_list.append(test_SA_token)
+    token_list.append(initial_test_users['SanketMASTUser2']['token'])
+    token_list.append(initial_test_users['SanketMASTAdmin']['token'])
+    token_list.append(initial_test_users['BcsDev']['token'])
+    token_list.append(initial_test_users['SanketMASTAdmin']['token'])
+
+    for user_token in token_list:
+        headers_auth['Authorization'] = "Bearer"+" "+user_token
+        resp = client.get("/v2/translation/project/tokens?project_id="+str(project_id)
+            ,headers=headers_auth)
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+        for item in resp.json():
+            assert_positive_get_tokens(item)
+
+        response = client.get(UNIT_URL+"/token-translations?project_id="+str(project_id)+
+            "&token="+all_tokens[0]['token']+"&sentence_id=41001001&offset=0&offset=4",
+            headers=headers_auth, json=post_obj_list)
+        assert response.status_code == 200
+        assert len(response.json()) > 0
+
+        response = client.get(UNIT_URL+'/draft?project_id='+str(project_id)+
+            "&output_format=alignment-json",headers=headers_auth)
+        assert response.status_code == 200
+        assert len(response.json()) > 0
+
+        response = client.get(UNIT_URL+"/sentences?project_id="+str(project_id)+
+            "&with_draft=True",headers=headers_auth)
+        assert response.status_code ==200
+        assert len(response.json()) > 0
+
+        response = client.get(UNIT_URL+"/progress?project_id="+str(project_id),
+        headers=headers_auth)
+        assert response.status_code ==200
+        assert len(response.json()) > 0
+
+        response = client.get(UNIT_URL+"/versification?project_id="+str(project_id)
+        ,headers=headers_auth)
+        assert response.status_code ==200
+        assert len(response.json()) > 0
+
+    #Not getting Content
+    #SanketMASTuser is not member of project
+    token_list = []
+    token_list.append(initial_test_users['VachanUser']['token'])
+    token_list.append(initial_test_users['SanketMASTUser']['token'])
+    token_list.append(initial_test_users['APIUser']['token'])
+    token_list.append(initial_test_users['VachanAdmin']['token'])
+
+    for user_token in token_list:
+        headers_auth['Authorization'] = "Bearer"+" "+user_token
+        resp = client.get("/v2/translation/project/tokens?project_id="+str(project_id)
+            ,headers=headers_auth)    
+        assert resp.status_code == 403
+        assert resp.json()['error'] == "Permission Denied"
+
+        response = client.get(UNIT_URL+"/token-translations?project_id="+str(project_id)+
+            "&token="+all_tokens[0]['token']+"&sentence_id=41001001&offset=0&offset=4",
+            headers=headers_auth, json=post_obj_list)
+        assert response.status_code == 403
+        assert response.json()['error'] == "Permission Denied"
+
+        response = client.get(UNIT_URL+'/draft?project_id='+str(project_id)+
+            "&output_format=alignment-json",headers=headers_auth)
+        assert response.status_code == 403
+        assert response.json()['error'] == "Permission Denied"
+
+        response = client.get(UNIT_URL+"/sentences?project_id="+str(project_id)+
+            "&with_draft=True",headers=headers_auth)
+        assert response.status_code == 403
+        assert response.json()['error'] == "Permission Denied"
+
+        response = client.get(UNIT_URL+"/progress?project_id="+str(project_id),
+        headers=headers_auth)
+        assert response.status_code == 403
+        assert response.json()['error'] == "Permission Denied"
+
+        response = client.get(UNIT_URL+"/versification?project_id="+str(project_id)
+        ,headers=headers_auth)
+        assert response.status_code == 403
+        assert response.json()['error'] == "Permission Denied"

--- a/app/test/test_smast_translation2.py
+++ b/app/test/test_smast_translation2.py
@@ -1,0 +1,554 @@
+'''tests for the translation workflow within SMAST projects continued'''
+
+from . import client
+from .test_agmt_projects import check_post as add_project
+from .conftest import initial_test_users
+from . import assert_input_validation_error, assert_not_available_content
+from . test_agmt_translation import UNIT_URL, assert_positive_get_sentence
+from . test_auth_basic import login,SUPER_PASSWORD,SUPER_USER,logout_user
+
+RESTORE_URL = '/v2/restore'
+headers_auth = {"contentType": "application/json",
+                "accept": "application/json",
+                "app":"SanketMAST"
+            }
+headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
+
+project_data = {
+    "projectName": "Test agmt draft",
+    "sourceLanguageCode": "en",
+    "targetLanguageCode": "ml"
+}
+
+source_sentences = [
+    {"sentenceId": 100,
+     "sentence": "In a jungle far away there lived a fox"},
+    {"sentenceId": 101,
+     "sentence": "The fox was friends with a tiger."},
+    {"sentenceId": 102,
+     "sentence": "They used to play together."},
+    {"sentenceId": 103,
+     "sentence": "One day the fox wished he had tiger's striped coat."},
+    {"sentenceId": 104,
+     "sentence": "The good friend tiger lent it to him."},
+    {"sentenceId": 105,
+     "sentence": "Tharjima illatha thettu vaakkukal mathram."},
+    {"sentenceId": 106,
+     "sentence": "Oru jungle allathe mattellam tharjima illatha thettu vaakkukal mathram."}     
+]
+
+def test_draft_update_positive():
+    '''Positive test for updating draft and draftMeta(Alignment) in a project'''
+    resp = add_project(project_data, auth_token=initial_test_users['SanketMASTUser']['token'])
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    put_data = {
+        "projectId": project_id,
+        "sentenceList":source_sentences
+    }
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    resp = client.get(f"{UNIT_URL}/sentences?project_id={project_id}", headers=headers_auth)
+    for sent in resp.json():
+        assert_positive_get_sentence(sent)
+
+    # translate just one word
+    put_data = [
+            {"sentenceId":100,
+             "draft": "കാട്",
+             "draftMeta":[
+                  [ [5,11], [0,4], "confirmed"]
+                ]
+            }
+    ]
+    resp = client.put(f"/v2/translation/project/draft?project_id={project_id}",
+        headers=headers_auth, json=put_data)
+    sents = resp.json()
+    assert len(sents) == 1
+    assert_positive_get_sentence(sents[0])
+    assert sents[0]["draft"] == "കാട്"
+    assert sents[0]["draftMeta"] == put_data[0]['draftMeta']
+
+    #fetch sentences to make sure
+    resp = client.get("/v2/translation/project/sentences?"+\
+        f"project_id={project_id}&sentence_id_list=100&with_draft=True",
+        headers=headers_auth, json=put_data)
+    sents = resp.json()
+    print(sents)
+    assert sents[0]["draft"] == "കാട്"
+    assert sents[0]["draftMeta"] == put_data[0]['draftMeta']
+
+    # edit the existing draft
+    put_data2 = [
+            {"sentenceId":100,
+             "draft": "ഒരു കാട്ടില്‍ ഒരു കുറുക്കന്‍ ജീവിച്ചിരുന്നു",
+             "draftMeta":[
+                  [ [3,4], [0,3], "confirmed"],
+                  [ [5,11], [4,11], "confirmed"],
+                  [ [32,33], [13,16], "confirmed"],
+                  [ [35,38], [18,26], "confirmed"]
+                ]
+            }
+    ]
+    resp = client.put(f"/v2/translation/project/draft?project_id={project_id}",
+        headers=headers_auth, json=put_data2)
+    sents = resp.json()
+    assert_positive_get_sentence(sents[0])
+    assert sents[0]["draft"] == "ഒരു കാട്ടില്‍ ഒരു കുറുക്കന്‍ ജീവിച്ചിരുന്നു"
+    assert sents[0]["draftMeta"] == put_data2[0]['draftMeta']
+
+    #fetch sentences again
+    resp = client.get("/v2/translation/project/sentences?"+\
+        f"project_id={project_id}&sentence_id_list=100&with_draft=True",
+        headers=headers_auth, json=put_data2)
+    sents = resp.json()
+    assert sents[0]["draft"] == put_data2[0]['draft']
+    assert sents[0]["draftMeta"] == put_data2[0]['draftMeta']
+
+def test_draft_update_negative():
+    '''Checking effective validations and error messages'''
+    resp = add_project(project_data, auth_token=initial_test_users['SanketMASTUser']['token'])
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    # incorrect project id
+    put_data = [
+            {"sentenceId":100,
+             "draft": "കാട്",
+             "draftMeta":[
+                  [ [5,11], [0,4], "confirmed"]
+                ]
+            }
+    ]
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
+    resp = client.put(f"/v2/translation/project/draft?project_id={project_id+1}",
+        headers=headers_auth, json=put_data)
+    assert resp.json()['error'] == "Requested Content Not Available"
+
+    # non existing sentence
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
+    resp = client.put(f"/v2/translation/project/draft?project_id={project_id}",
+        headers=headers_auth, json=put_data)
+    assert resp.json()['error'] == "Requested Content Not Available"
+
+    # upload source and repeat last action
+    put_data_source = {
+        "projectId": project_id,
+        "sentenceList":source_sentences
+    }
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data_source)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
+    resp = client.put(f"/v2/translation/project/draft?project_id={project_id}",
+        headers=headers_auth, json=put_data)
+    assert resp.json()[0]["draft"] == put_data[0]['draft']
+
+    # incorrect user
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser2']['token']
+    resp = client.put(f"/v2/translation/project/draft?project_id={project_id}",
+        headers=headers_auth, json=put_data)
+    assert resp.json()['error'] == "Permission Denied"
+
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
+
+    # incorrect payloads
+    put_data2 = [
+            {
+             # "sentenceId":100, no sentenceId
+             "draft": "കാട്",
+             "draftMeta":[
+                  [ [5,11], [0,4], "confirmed"]
+                ]
+            }
+    ]
+    resp = client.put(f"/v2/translation/project/draft?project_id={project_id}",
+        headers=headers_auth, json=put_data2)
+    assert resp.status_code == 422
+
+    put_data2 = [
+            {
+             "sentenceId":100, 
+             # "draft": "കാട്", no draft
+             "draftMeta":[
+                  [ [5,11], [0,4], "confirmed"]
+                ]
+            }
+    ]
+    resp = client.put(f"/v2/translation/project/draft?project_id={project_id}",
+        headers=headers_auth, json=put_data2)
+    assert resp.status_code == 422
+
+    put_data2 = [
+            {
+             "sentenceId":100, 
+             "draft": "കാട്",
+             # "draftMeta":[  no draft
+             #      [ [5,11], [0,4], "confirmed"]
+             #    ]
+            }
+    ]
+    resp = client.put(f"/v2/translation/project/draft?project_id={project_id}",
+        headers=headers_auth, json=put_data2)
+    assert resp.status_code == 422
+
+    # incorrect index of target segment
+    put_data2 = [
+            {
+             "sentenceId":100, 
+             "draft": "കാട്",
+             "draftMeta":[  
+                  [ [5,11], [0,10], "confirmed"]
+                ]
+            }
+    ]
+    resp = client.put(f"/v2/translation/project/draft?project_id={project_id}",
+        headers=headers_auth, json=put_data2)
+    assert resp.status_code == 422
+    assert resp.json()['details'] == "Incorrect metadata:Target segment (0, 10), is improper!"
+
+
+def test_empty_draft_initalization():
+    '''Bugfix test for #452 after the changes in #448'''
+    resp = add_project(project_data, auth_token=initial_test_users['SanketMASTUser']['token'])
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    put_data = {
+        "projectId": project_id,
+        "sentenceList":source_sentences
+    }
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    # Ensure draft is set to ""
+    resp = client.get(f"{UNIT_URL}/sentences?project_id={project_id}&with_draft=True",
+        headers=headers_auth)
+    for sent in resp.json():
+        assert_positive_get_sentence(sent)
+        assert sent["draft"] == ""
+
+    #Ensure draft if still empty when there is no suggestion
+    resp = client.put(f"{UNIT_URL}/suggestions?project_id={project_id}&sentence_id_list={105}",
+        headers=headers_auth)
+    assert resp.status_code == 201
+    assert resp.json()[0]['draft'] == ""
+
+    # Add a gloss to make sure there will be suggestions
+    tokens_trans = [
+        {"token":"jungle", "translations":["കാട്"]}
+    ]
+    response = client.post('/v2/nlp/learn/gloss?source_language=en&target_language=ml',
+        headers=headers_auth, json=tokens_trans)
+    assert response.status_code == 201
+    assert response.json()['message'] == "Added to glossary"
+
+    resp = client.put(f"{UNIT_URL}/suggestions?project_id={project_id}&sentence_id_list=100"+\
+        "&sentence_id_list=106",
+        headers=headers_auth)
+    assert resp.status_code == 201
+    assert resp.json()[1]['draft'] == "കാട്" # only one suggestion
+    assert "കാട്" in resp.json()[0]['draft'] # at least one suggestion
+    found_jungle_meta = False
+    found_untranslated = False
+    for meta in resp.json()[0]['draftMeta']:
+        if meta[0] == [5,11] and meta[2] == "suggestion":
+            found_jungle_meta = True
+            print("draft:", resp.json()[0]['draft'])
+            print("draft.index('കാട്'')",resp.json()[0]['draft'].index("കാട്"))
+            trans_index = resp.json()[0]['draft'].index("കാട്")
+            assert meta[1][0] == trans_index
+        elif meta[2] == "untranslated":
+            found_untranslated = True
+    assert found_jungle_meta
+    assert found_untranslated
+
+def test_draft_meta_validation():
+    '''Bugfix test for #479 after the changes in PR #481'''
+    resp = add_project(project_data, auth_token=initial_test_users['SanketMASTUser']['token'])
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    put_data = {
+        "projectId": project_id,
+        "sentenceList":source_sentences
+    }
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    #Get suggestions
+    resp = client.put(f"/v2/translation/project/suggestions?project_id={project_id}&sentenceIdList=100", 
+        headers=headers_auth)
+    assert resp.status_code == 201
+    resp_draft_meta = resp.json()[0]['draftMeta']
+    print("draftMeta:", resp_draft_meta)
+    empty_seg = False
+    for seg in resp_draft_meta:
+        if seg[0][0] == seg[0][1] or seg[1][0] == seg[1][1]:
+            empty_seg = True
+            break
+    # assert empty_seg
+    
+    # PUT the draft meta back to server
+    json_data = [{
+        "sentenceId":100,
+        "draft":resp.json()[0]['draft'],
+        "draftMeta":resp_draft_meta
+    }]
+    resp = client.put(f"/v2/translation/project/draft?project_id={project_id}",
+        headers=headers_auth, json=json_data)
+    assert resp.status_code == 201
+
+def test_space_in_suggested_draft():
+    '''BUgfix text for #485, after changes in PR #486'''
+    resp = add_project(project_data, auth_token=initial_test_users['SanketMASTUser']['token'])
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    put_data = {
+        "projectId": project_id,
+        "sentenceList":source_sentences
+    }
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    # Add a gloss to ensure some suggestion in output
+    tokens_trans = [
+        {"token":"jungle", "translations":["കാട്"]},
+        {"token":"far", "translations":["ദൂരെ"]},
+        {"token":"fox", "translations":["കുറുക്കന്‍"]}
+    ]
+    response = client.post('/v2/nlp/learn/gloss?source_language=en&target_language=ml',
+        headers=headers_auth, json=tokens_trans)
+    assert response.status_code == 201
+    assert response.json()['message'] == "Added to glossary"
+
+
+    #Get suggestions
+    resp = client.put(f"/v2/translation/project/suggestions?project_id={project_id}&sentenceIdList=100", 
+        headers=headers_auth)
+    assert resp.status_code == 201
+    resp_obj = resp.json()
+    assert resp_obj[0]['draft'] != ""
+    assert not resp_obj[0]['draft'].startswith(" ")
+
+    #Get suggestions again
+    resp = client.put(f"/v2/translation/project/suggestions?project_id={project_id}&sentenceIdList=100", 
+        headers=headers_auth)
+    assert resp.status_code == 201
+    resp_obj = resp.json()
+    assert resp_obj[0]['draft'] != ""
+    assert not resp_obj[0]['draft'].startswith(" ")
+
+def test_delete_sentence():
+    '''Test the removal of a sentence from project'''
+
+    #Adding Project and sentences into it
+    resp = add_project(project_data, auth_token=initial_test_users['SanketMASTUser']['token'])
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    put_data = {
+        "projectId": project_id,
+        "sentenceList":source_sentences
+    }
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    # Check sentences are added
+    resp = client.get(f"{UNIT_URL}/sentences?project_id={project_id}", headers=headers_auth)
+    sentence_id1 = resp.json()[0]['sentenceId']
+    sentence_id2 = resp.json()[1]['sentenceId']
+    for sent in resp.json():
+        assert_positive_get_sentence(sent)
+
+
+    #deleting sentence with no auth
+    headers = {"contentType": "application/json",
+                "accept": "application/json",
+                "app":"SanketMAST"
+            }
+    resp = client.delete(f"{UNIT_URL}/sentences?project_id={project_id}&sentence_id={sentence_id1}",
+            headers=headers)
+    assert resp.status_code == 401
+    assert resp.json()['details'] == "Access token not provided or user not recognized."
+
+    #Deleting Sentence with unauthorized users - Negative Test
+    for user in ['APIUser','VachanAdmin','VachanUser','BcsDev','SanketMASTUser']:
+        headers_auth['Authorization'] = "Bearer"+" "+initial_test_users[user]['token']
+        response = client.delete(f"{UNIT_URL}/sentences?project_id={project_id}&sentence_id={sentence_id1}",
+                headers=headers_auth)
+        assert response.status_code == 403
+        assert response.json()['error'] == 'Permission Denied'
+
+    # Delete as SanketMASTAdmin - Positive test
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    response = client.delete(f"{UNIT_URL}/sentences?project_id={project_id}&sentence_id={sentence_id1}",
+            headers=headers_auth)
+    assert response.status_code == 201
+    assert "successfull" in response.json()['message']
+
+    # Check get sentence to ensure deleted sentence is not present
+    get_response = client.get(UNIT_URL+"/sentences?project_id="+str(project_id)+
+        "&sentence_id_list="+str(sentence_id1),headers=headers_auth)
+    assert_not_available_content(get_response)
+   
+    #Create and Delete sentence with superadmin - Positive test
+    # Login as Super Admin
+    sa_data = {
+            "user_email": SUPER_USER,
+            "password": SUPER_PASSWORD
+        }
+    response = login(sa_data)
+    assert response.json()['message'] == "Login Succesfull"
+    test_user_token = response.json()["token"]
+    headers_auth['Authorization'] = "Bearer"+" "+test_user_token
+
+    response = client.delete(f"{UNIT_URL}/sentences?project_id={project_id}&sentence_id={sentence_id2}",
+            headers=headers_auth)
+    assert response.status_code == 201
+    assert "successfull" in response.json()['message']
+
+    # Check get sentence to ensure deleted sentence is not present
+    get_response = client.get(UNIT_URL+"/sentences?project_id="+str(project_id)+
+        "&sentence_id_list="+str(sentence_id2),headers=headers_auth)
+    assert_not_available_content(get_response)
+
+    #Delete not available sentence
+    response = client.delete(f"{UNIT_URL}/sentences?project_id={project_id}&sentence_id=9999",
+            headers=headers_auth)
+    assert response.status_code == 404
+    assert "Requested Content Not Available" in response.json()['error']
+
+
+def test_restore_sentence():
+    '''positive test case, checking for correct return object'''
+    #only Super Admin can restore deleted data
+    #Creating and Deleting project sentence
+    #Adding Project and sentences into it
+    resp = add_project(project_data, auth_token=initial_test_users['SanketMASTAdmin']['token'])
+    project_id = resp.json()['data']['projectId']
+
+    put_data = {
+        "projectId": project_id,
+        "sentenceList":source_sentences
+    }
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    delete_resp = client.delete(f"{UNIT_URL}/sentences?project_id={project_id}&sentence_id=100",
+            headers=headers_auth)
+
+    #Ensure deleted sentence is not present
+    get_response = client.get(UNIT_URL+"/sentences?project_id="+str(project_id)+
+        "&sentence_id_list=100",headers=headers_auth)
+    assert_not_available_content(get_response)
+    
+    deleteditem_id = delete_resp.json()['data']['itemId']
+    data = {"itemId": deleteditem_id}
+
+    #Restoring data
+    #Restore user without authentication - Negative Test
+    headers = {"contentType": "application/json",
+                "accept": "application/json",
+                "app":"SanketMAST"
+            }
+    response = client.put(RESTORE_URL, headers=headers, json=data)
+    assert response.status_code == 401
+    assert response.json()['error'] == 'Authentication Error'
+
+    #Restore project user with other API user,VachanAdmin,SanketMASTAdmin,SanketMASTUser,VachanUser,BcsDev - Negative Test
+    for user in ['APIUser','VachanAdmin','SanketMASTAdmin','SanketMASTUser','VachanUser','BcsDev']:
+        headers_auth['Authorization'] = "Bearer"+" "+initial_test_users[user]['token']
+        response = client.put(RESTORE_URL, headers=headers_auth, json=data)
+        assert response.status_code == 403
+        assert response.json()['error'] == 'Permission Denied'
+
+    #Restore Project User with Super Admin - Positive Test
+     # Login as Super Admin
+    sa_data = {
+            "user_email": SUPER_USER,
+            "password": SUPER_PASSWORD
+        }
+    response = login(sa_data)
+    assert response.json()['message'] == "Login Succesfull"
+    test_user_token = response.json()["token"]
+    headers_auth['Authorization'] = "Bearer"+" "+test_user_token
+
+    response = client.put(RESTORE_URL, headers=headers_auth, json=data)
+    assert response.status_code == 201
+    assert response.json()['message'] == \
+    f"Deleted Item with identity {deleteditem_id} restored successfully"
+
+     #Ensure deleted sentence is not present
+    get_response = client.get(UNIT_URL+"/sentences?project_id="+str(project_id)+
+        "&sentence_id_list=100",headers=headers_auth)
+    assert get_response.status_code ==200
+    assert len(get_response.json())== 1
+    for item in get_response.json():
+        assert_positive_get_sentence(item)
+
+    #restore with missing data - Negative Test
+    data = {}
+    response = client.put(RESTORE_URL, headers=headers_auth, json=data)
+    assert_input_validation_error(response)
+
+    #Restore with invalid item id - Negative Test
+    data = {"itemId":9999}
+    response = client.put(RESTORE_URL, headers=headers_auth, json=data)
+    assert response.status_code == 404
+    assert response.json()['error'] == "Requested Content Not Available"
+    logout_user(test_user_token)
+
+def test_suggestion_when_token_overlaps_confirmed_segment():
+    # Testing bug fix https://github.com/Bridgeconn/vachan-api/issues/542
+    resp = add_project(project_data, auth_token=initial_test_users['SanketMASTAdmin']['token'])
+    project_id = resp.json()['data']['projectId']
+
+    put_data = {
+        "projectId": project_id,
+        "sentenceList": [
+            {
+            "sentenceId": 57001002,
+            "surrogateId": "tit 1:2",
+            "sentence":"This faith and knowledge make us sure that we have eternal life. God promised that life to us before time began—and God does not lie."
+            }
+        ]
+    }
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    # add a translation for just "not" when it occurs as "doesnot"
+    update_draft_url = f"/v2/translation/project/draft?project_id={project_id}"
+    data = [{ "draft": "they this",
+        "draftMeta": [ [ [ 0, 4 ], [ 9, 9 ], "untranslated" ], [ [ 4, 5 ], [ 9, 9 ], "untranslated" ], [ [ 5, 10 ], [ 9, 9 ], "untranslated" ], [ [ 10, 11 ], [ 9, 9 ], "untranslated" ], [ [ 11, 24 ], [ 9, 9 ], "untranslated" ], [ [ 24, 25 ], [ 9, 9 ], "untranslated" ], [ [ 25, 29 ], [ 9, 9 ], "untranslated" ], [ [ 29, 30 ], [ 9, 9 ], "untranslated" ], [ [ 30, 32 ], [ 9, 9 ], "untranslated" ], [ [ 32, 33 ], [ 9, 9 ], "untranslated" ], [ [ 33, 37 ], [ 9, 9 ], "untranslated" ], [ [ 37, 38 ], [ 9, 9 ], "untranslated" ], [ [ 38, 42 ], [ 9, 9 ], "untranslated" ], [ [ 42, 43 ], [ 9, 9 ], "untranslated" ], [ [ 43, 45 ], [ 9, 9 ], "untranslated" ], [ [ 45, 46 ], [ 9, 9 ], "untranslated" ], [ [ 46, 58 ], [ 9, 9 ], "untranslated" ], [ [ 58, 59 ], [ 9, 9 ], "untranslated" ], [ [ 59, 63 ], [ 9, 9 ], "untranslated" ], [ [ 63, 65 ], [ 9, 9 ], "untranslated" ], [ [ 65, 68 ], [ 9, 9 ], "untranslated" ], [ [ 68, 69 ], [ 9, 9 ], "untranslated" ], [ [ 69, 77 ], [ 9, 9 ], "untranslated" ], [ [ 77, 78 ], [ 9, 9 ], "untranslated" ], [ [ 78, 82 ], [ 9, 9 ], "untranslated" ], [ [ 82, 83 ], [ 9, 9 ], "untranslated" ], [ [ 83, 87 ], [ 9, 9 ], "untranslated" ], [ [ 87, 88 ], [ 9, 9 ], "untranslated" ], [ [ 88, 93 ], [ 9, 9 ], "untranslated" ], [ [ 93, 94 ], [ 9, 9 ], "untranslated" ], [ [ 94, 105 ], [ 9, 9 ], "untranslated" ], [ [ 105, 106 ], [ 9, 9 ], "untranslated" ], [ [ 106, 111 ], [ 9, 9 ], "untranslated" ], [ [ 111, 112 ], [ 9, 9 ], "untranslated" ], [ [ 112, 119 ], [ 9, 9 ], "untranslated" ], [ [ 119, 120 ], [ 9, 9 ], "untranslated" ], [ [ 132, 133 ], [ 9, 9 ], "untranslated" ], [ [ 125, 128 ], [ 5, 9 ], "confirmed" ], [ [ 129, 132 ], [ 0, 4 ], "confirmed" ] ],
+        "sentenceId": 57001002 }]
+    update_resp = client.put(update_draft_url,
+                           json=data,
+                             headers={'Authorization': f'bearer {initial_test_users["SanketMASTAdmin"]["token"]}',
+                                      'app':"SanketMAST"})
+    assert update_resp.status_code == 201
+
+
+    # Suggestion call 1
+    suggest_url =  f"/v2/translation/project/suggestions?project_id={project_id}&sentence_id_list=57001002"
+    suggest_resp = client.put(suggest_url, 
+                             headers={'Authorization': f"bearer {initial_test_users['SanketMASTAdmin']['token']}",
+                                      'app':"SanketMAST"})
+    assert suggest_resp.status_code == 201
+
+    # Suggestion call 2
+    suggest_url =  f"/v2/translation/project/suggestions?project_id={project_id}&sentence_id_list=57001002"
+    suggest_resp = client.put(suggest_url, 
+                             headers={'Authorization': f"bearer {initial_test_users['SanketMASTAdmin']['token']}",
+                                      'app':"SanketMAST"})
+    assert suggest_resp.status_code == 201
+


### PR DESCRIPTION
- Implement #551 
  - Define a new app called "SanketMAST"
  - Define two user roles "SanketMASTUser" and "SanketMASTAdmin"
  - Make code changes in authentication.py, pydantic and graphql schemas to support these changes
  - Replicate access permissions of Autographa app for SanketMAST as well
  - Include the new users in initial_test_users in pytest session fixture
  - Replicate all the agmt tests for SanketMAST aswell
- Change version number to 2.0.0-beta.8

- NOTE: All these code changes required ( in authentication.py, pydantic and graphql schemas)  should be eliminated after the completion of https://github.com/Bridgeconn/vachan-api/issues/457 so that adding a new App can be entirely a vachan admin user action