### PR TITLE
Bugfix/draft missing confirmed word after suggestions

### DIFF
--- a/app/crud/nlp_tokenization.py
+++ b/app/crud/nlp_tokenization.py
@@ -319,8 +319,12 @@ def replace_token(source, token_offset, translation,draft_meta, tag="confirmed",
         src_seg_offset = meta[0]
         draft_seg_offset = meta[1]
         status = meta[2]
-        intersection = set(range(token_offset[0],token_offset[1])).intersection(
-            range(src_seg_offset[0],src_seg_offset[1]))
+        if src_seg_offset[0] == src_seg_offset[1] and src_seg_offset[0] != token_offset[0]:
+            intersection = set(range(token_offset[0],token_offset[1])). intersection(
+                [src_seg_offset[0]])
+        else:
+            intersection = set(range(token_offset[0],token_offset[1])).intersection(
+                range(src_seg_offset[0],src_seg_offset[1]))
         if len(intersection) > 0: # our area of interest overlaps with this segment
             updated_draft, updated_meta, translation_offset = replace_token_inside(
                 token_offset=token_offset,
@@ -343,4 +347,5 @@ def replace_token(source, token_offset, translation,draft_meta, tag="confirmed",
                 updated_meta=updated_meta,
                 meta=meta
                 )
+    utils.validate_draft_meta(source, updated_draft, updated_meta)
     return updated_draft, updated_meta

--- a/app/crud/projects_crud.py
+++ b/app/crud/projects_crud.py
@@ -4,7 +4,6 @@ projects are included in nlp_crud module'''
 
 import re
 import datetime
-import itertools
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
@@ -310,49 +309,6 @@ def obtain_project_draft(db_:Session, project_id, books, sentence_id_list, sente
         }
     return response
 
-def validate_draft_meta(sentence, draft, draft_meta):
-    '''Check if indices are proper in draftMeta, as per values in sentence and draft'''
-    src_segs = [meta[0] for meta in draft_meta]
-    trg_segs = [meta[1] for meta in draft_meta]
-    try:
-        #Ensure the offset ranges dont overlap
-        for seg1, seg2 in itertools.product(src_segs, src_segs):
-            if seg1 != seg2:
-                intersection = set(range(seg1[0],seg1[1])).intersection(
-                    range(seg2[0],seg2[1]))
-                assert not intersection, f"Source segments {seg1} and {seg2} overlaps!"
-        for seg1, seg2 in itertools.product(trg_segs, trg_segs):
-            if seg1 != seg2:
-                intersection = set(range(seg1[0],seg1[1])).intersection(
-                    range(seg2[0],seg2[1]))
-                assert not intersection, f"Target segments {seg1} and {seg2} overlaps!"
-        # Ensure the index values are within the range of string length and from left to right
-        # and non empty
-        src_len = len(sentence)
-        for seg in src_segs:
-            assert 0 <= seg[0] <= seg[1] <= src_len, f"Source segment {seg}, is improper!"
-        trg_len = len(draft)
-        for seg in trg_segs:
-            assert 0 <= seg[0] <= seg[1] <= trg_len, f"Target segment {seg}, is improper!"
-        for meta in draft_meta:
-            assert meta[2] in ['confirmed', 'suggestion', 'untranslated'],\
-                "invalid value where confirmed, suggestion or untranslated is expected"
-
-        # Ensure all portions of draft have a target segment corresponding to it
-        sorted_trg_segs = sorted(trg_segs)
-        pointer = 0
-        for seg in sorted_trg_segs:
-            assert seg[0] == pointer, "All portions of the draft should have "+\
-                                    "a draftmeta segment showing its status. "+\
-                                    f"Expecting a draft segment starting with {pointer}"
-            pointer = seg[1]
-        assert sorted_trg_segs[-1][1] == trg_len, "All portions of the draft should have "+\
-                                    "a draftmeta segment showing its status. "+\
-                                    f"Expecting a draft segment ending in {pointer}"
-    except AssertionError as exe:
-        raise UnprocessableException("Incorrect metadata:"+str(exe)) from exe
-    except Exception as exe:
-        raise UnprocessableException("Incorrect metadata.") from exe
 
 def update_project_draft(db_:Session, project_id, sentence_list, user_id):
     '''Directly write to the draft and draftMeta fields of project sentences'''
@@ -370,7 +326,7 @@ def update_project_draft(db_:Session, project_id, sentence_list, user_id):
         if not sent:
             raise NotAvailableException(f"Sentence id: {input_sent.sentenceId},"+\
                 " not found in project")
-        validate_draft_meta(sentence=sent.sentence, draft=input_sent.draft,
+        utils.validate_draft_meta(sentence=sent.sentence, draft=input_sent.draft,
             draft_meta=input_sent.draftMeta)
         sent.draft = input_sent.draft
         sent.draftMeta = input_sent.draftMeta

--- a/app/crud/projects_crud.py
+++ b/app/crud/projects_crud.py
@@ -337,6 +337,18 @@ def validate_draft_meta(sentence, draft, draft_meta):
         for meta in draft_meta:
             assert meta[2] in ['confirmed', 'suggestion', 'untranslated'],\
                 "invalid value where confirmed, suggestion or untranslated is expected"
+
+        # Ensure all portions of draft have a target segment corresponding to it
+        sorted_trg_segs = sorted(trg_segs)
+        pointer = 0
+        for seg in sorted_trg_segs:
+            assert seg[0] == pointer, "All portions of the draft should have "+\
+                                    "a draftmeta segment showing its status. "+\
+                                    f"Expecting a draft segment starting with {pointer}"
+            pointer = seg[1]
+        assert sorted_trg_segs[-1][1] == trg_len, "All portions of the draft should have "+\
+                                    "a draftmeta segment showing its status. "+\
+                                    f"Expecting a draft segment ending in {pointer}"
     except AssertionError as exe:
         raise UnprocessableException("Incorrect metadata:"+str(exe)) from exe
     except Exception as exe:

--- a/app/crud/utils.py
+++ b/app/crud/utils.py
@@ -1,11 +1,13 @@
 '''Utility functions'''
 import subprocess
 import json
+import itertools
+
 import unicodedata
 from unidecode import unidecode
 import requests
 
-from custom_exceptions import TypeException
+from custom_exceptions import TypeException, UnprocessableException
 #pylint: disable=R1732
 def normalize_unicode(text, form="NFKC"):
     '''to normalize text contents before adding them to DB'''
@@ -187,3 +189,48 @@ def convert_dict_to_sqlalchemy(input_obj, target_class):
         kwargs[key] = input_obj[key]
     new_obj = target_class(**kwargs)
     return new_obj
+
+def validate_draft_meta(sentence, draft, draft_meta):
+    '''Check if indices are proper in draftMeta, as per values in sentence and draft'''
+    src_segs = [list(meta[0]) for meta in draft_meta]
+    trg_segs = [list(meta[1]) for meta in draft_meta]
+    try:
+        #Ensure the offset ranges dont overlap
+        for seg1, seg2 in itertools.product(src_segs, src_segs):
+            if seg1 != seg2:
+                intersection = set(range(seg1[0],seg1[1])).intersection(
+                    range(seg2[0],seg2[1]))
+                assert not intersection, f"Source segments {seg1} and {seg2} overlaps!"
+        for seg1, seg2 in itertools.product(trg_segs, trg_segs):
+            if seg1 != seg2:
+                intersection = set(range(seg1[0],seg1[1])).intersection(
+                    range(seg2[0],seg2[1]))
+                assert not intersection, f"Target segments {seg1} and {seg2} overlaps!"
+        # Ensure the index values are within the range of string length and from left to right
+        # and non empty
+        src_len = len(sentence)
+        for seg in src_segs:
+            assert 0 <= seg[0] <= seg[1] <= src_len, f"Source segment {seg}, is improper!"
+        trg_len = len(draft)
+        for seg in trg_segs:
+            assert 0 <= seg[0] <= seg[1] <= trg_len, f"Target segment {seg}, is improper!"
+        for meta in draft_meta:
+            assert meta[2] in ['confirmed', 'suggestion', 'untranslated'],\
+                "invalid value where confirmed, suggestion or untranslated is expected"
+
+        # Ensure all portions of draft have a target segment corresponding to it
+        sorted_trg_segs = sorted(trg_segs)
+        pointer = 0
+        for seg in sorted_trg_segs:
+            assert seg[0] == pointer, "All portions of the draft should have "+\
+                                    "a draftmeta segment showing its status. "+\
+                                    f"Expecting a draft segment starting with {pointer}"
+            pointer = seg[1]
+        if trg_len > 0:
+            assert sorted_trg_segs[-1][1] == trg_len, "All portions of the draft should have "+\
+                                    "a draftmeta segment showing its status. "+\
+                                    f"Expecting a draft segment ending in {trg_len}"
+    except AssertionError as exe:
+        raise UnprocessableException("Incorrect metadata:"+str(exe)) from exe
+    except Exception as exe:
+        raise UnprocessableException("Incorrect metadata.") from exe

--- a/app/routers/translation_apis.py
+++ b/app/routers/translation_apis.py
@@ -444,6 +444,8 @@ async def generate_draft(request: Request,sentence_list:List[schemas_nlp.DraftIn
     usfm, text, csv or alignment-json'''
     log.info('In generate_draft')
     log.debug('sentence_list:%s, doc_type:%s',sentence_list, doc_type)
+    for sent in sentence_list:
+        projects_crud.validate_draft_meta(sent.sentence, sent.draft, sent.draftMeta)
     return nlp_crud.obtain_draft(sentence_list, doc_type)
 
 @router.put('/v2/translation/suggestions', response_model=List[schemas_nlp.Sentence],
@@ -463,6 +465,8 @@ async def suggest_translation(request: Request,
     log.info("In suggest_translation")
     log.debug('source_language:%s, target_language:%s, sentence_list:%s,punctuations:%s\
         stopwords:%s', source_language, target_language, sentence_list, punctuations, stopwords)
+    for sent in sentence_list:
+        projects_crud.validate_draft_meta(sent.sentence, sent.draft, sent.draftMeta)
     return nlp_crud.auto_translate(db_, sentence_list, source_language, target_language,
         punctuations=punctuations, stopwords=stopwords)
 

--- a/app/routers/translation_apis.py
+++ b/app/routers/translation_apis.py
@@ -7,7 +7,7 @@ from sqlalchemy.orm import Session
 
 from dependencies import get_db, log, AddHiddenInput
 from schema import schemas, schemas_nlp, schema_auth, schema_content
-from crud import nlp_crud, projects_crud, nlp_sw_crud, structurals_crud
+from crud import nlp_crud, projects_crud, nlp_sw_crud, structurals_crud, utils
 from custom_exceptions import GenericException
 from routers import content_apis
 from auth.authentication import get_user_or_none,get_auth_access_check_decorator
@@ -445,7 +445,8 @@ async def generate_draft(request: Request,sentence_list:List[schemas_nlp.DraftIn
     log.info('In generate_draft')
     log.debug('sentence_list:%s, doc_type:%s',sentence_list, doc_type)
     for sent in sentence_list:
-        projects_crud.validate_draft_meta(sent.sentence, sent.draft, sent.draftMeta)
+        if sent.draftMeta is not None and sent.draftMeta != []:
+            utils.validate_draft_meta(sent.sentence, sent.draft, sent.draftMeta)
     return nlp_crud.obtain_draft(sentence_list, doc_type)
 
 @router.put('/v2/translation/suggestions', response_model=List[schemas_nlp.Sentence],
@@ -466,7 +467,8 @@ async def suggest_translation(request: Request,
     log.debug('source_language:%s, target_language:%s, sentence_list:%s,punctuations:%s\
         stopwords:%s', source_language, target_language, sentence_list, punctuations, stopwords)
     for sent in sentence_list:
-        projects_crud.validate_draft_meta(sent.sentence, sent.draft, sent.draftMeta)
+        if sent.draftMeta is not None and sent.draftMeta != []:
+            utils.validate_draft_meta(sent.sentence, sent.draft, sent.draftMeta)
     return nlp_crud.auto_translate(db_, sentence_list, source_language, target_language,
         punctuations=punctuations, stopwords=stopwords)
 

--- a/app/test/test_agmt_translation2.py
+++ b/app/test/test_agmt_translation2.py
@@ -87,15 +87,20 @@ def test_draft_update_positive():
              "draft": "ഒരു കാട്ടില്‍ ഒരു കുറുക്കന്‍ ജീവിച്ചിരുന്നു",
              "draftMeta":[
                   [ [3,4], [0,3], "confirmed"],
+                  [ [5,5], [3,4], "confirmed"],
                   [ [5,11], [4,11], "confirmed"],
+                  [ [11,11], [11,13], "confirmed"],
                   [ [32,33], [13,16], "confirmed"],
-                  [ [35,38], [18,26], "confirmed"]
+                  [ [33,33], [16,18], "confirmed"],
+                  [ [35,38], [18,26], "confirmed"],
+                  [ [38,38], [26,43], "untranslated"],
                 ]
             }
     ]
     resp = client.put(f"/v2/translation/project/draft?project_id={project_id}",
         headers=headers_auth, json=put_data2)
     sents = resp.json()
+    print(sents)
     assert_positive_get_sentence(sents[0])
     assert sents[0]["draft"] == "ഒരു കാട്ടില്‍ ഒരു കുറുക്കന്‍ ജീവിച്ചിരുന്നു"
     assert sents[0]["draftMeta"] == put_data2[0]['draftMeta']
@@ -209,7 +214,7 @@ def test_draft_update_negative():
     resp = client.put(f"/v2/translation/project/draft?project_id={project_id}",
         headers=headers_auth, json=put_data2)
     assert resp.status_code == 422
-    assert resp.json()['details'] == "Incorrect metadata:Target segment (0, 10), is improper!"
+    assert resp.json()['details'] == "Incorrect metadata:Target segment [0, 10], is improper!"
 
 
 def test_empty_draft_initalization():
@@ -529,7 +534,46 @@ def test_suggestion_when_token_overlaps_confirmed_segment():
     # add a translation for just "not" when it occurs as "doesnot"
     update_draft_url = f"/v2/translation/project/draft?project_id={project_id}"
     data = [{ "draft": "they this",
-        "draftMeta": [ [ [ 0, 4 ], [ 9, 9 ], "untranslated" ], [ [ 4, 5 ], [ 9, 9 ], "untranslated" ], [ [ 5, 10 ], [ 9, 9 ], "untranslated" ], [ [ 10, 11 ], [ 9, 9 ], "untranslated" ], [ [ 11, 24 ], [ 9, 9 ], "untranslated" ], [ [ 24, 25 ], [ 9, 9 ], "untranslated" ], [ [ 25, 29 ], [ 9, 9 ], "untranslated" ], [ [ 29, 30 ], [ 9, 9 ], "untranslated" ], [ [ 30, 32 ], [ 9, 9 ], "untranslated" ], [ [ 32, 33 ], [ 9, 9 ], "untranslated" ], [ [ 33, 37 ], [ 9, 9 ], "untranslated" ], [ [ 37, 38 ], [ 9, 9 ], "untranslated" ], [ [ 38, 42 ], [ 9, 9 ], "untranslated" ], [ [ 42, 43 ], [ 9, 9 ], "untranslated" ], [ [ 43, 45 ], [ 9, 9 ], "untranslated" ], [ [ 45, 46 ], [ 9, 9 ], "untranslated" ], [ [ 46, 58 ], [ 9, 9 ], "untranslated" ], [ [ 58, 59 ], [ 9, 9 ], "untranslated" ], [ [ 59, 63 ], [ 9, 9 ], "untranslated" ], [ [ 63, 65 ], [ 9, 9 ], "untranslated" ], [ [ 65, 68 ], [ 9, 9 ], "untranslated" ], [ [ 68, 69 ], [ 9, 9 ], "untranslated" ], [ [ 69, 77 ], [ 9, 9 ], "untranslated" ], [ [ 77, 78 ], [ 9, 9 ], "untranslated" ], [ [ 78, 82 ], [ 9, 9 ], "untranslated" ], [ [ 82, 83 ], [ 9, 9 ], "untranslated" ], [ [ 83, 87 ], [ 9, 9 ], "untranslated" ], [ [ 87, 88 ], [ 9, 9 ], "untranslated" ], [ [ 88, 93 ], [ 9, 9 ], "untranslated" ], [ [ 93, 94 ], [ 9, 9 ], "untranslated" ], [ [ 94, 105 ], [ 9, 9 ], "untranslated" ], [ [ 105, 106 ], [ 9, 9 ], "untranslated" ], [ [ 106, 111 ], [ 9, 9 ], "untranslated" ], [ [ 111, 112 ], [ 9, 9 ], "untranslated" ], [ [ 112, 119 ], [ 9, 9 ], "untranslated" ], [ [ 119, 120 ], [ 9, 9 ], "untranslated" ], [ [ 132, 133 ], [ 9, 9 ], "untranslated" ], [ [ 125, 128 ], [ 5, 9 ], "confirmed" ], [ [ 129, 132 ], [ 0, 4 ], "confirmed" ] ],
+        "draftMeta": [ [ [ 0, 4 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 4, 5 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 5, 10 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 10, 11 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 11, 24 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 24, 25 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 25, 29 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 29, 30 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 30, 32 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 32, 33 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 33, 37 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 37, 38 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 38, 42 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 42, 43 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 43, 45 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 45, 46 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 46, 58 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 58, 59 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 59, 63 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 63, 65 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 65, 68 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 68, 69 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 69, 77 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 77, 78 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 78, 82 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 82, 83 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 83, 87 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 87, 88 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 88, 93 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 93, 94 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 94, 105 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 105, 106 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 106, 111 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 111, 112 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 112, 119 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 119, 120 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 132, 133 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 125, 128 ], [ 5, 9 ], "confirmed" ],
+                       [ [ 129, 132 ], [ 0, 4 ], "confirmed" ],
+                       [ [ 125, 125 ], [ 4, 5 ], "confirmed" ] ],
         "sentenceId": 57001002 }]
     update_resp = client.put(update_draft_url,
                            json=data,
@@ -594,3 +638,36 @@ def test_glossupdate_upon_draft_update():
         headers=headers_auth)
     assert resp.status_code == 200
     assert "കാട്" in resp.json()['translations']
+
+def test_draftmeta_validation():
+    '''All protions of the draft should have a draftmeta segment
+    issue #602'''
+    resp = add_project(project_data, auth_token=initial_test_users['AgUser']['token'])
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    put_data = {
+        "projectId": project_id,
+        "sentenceList":source_sentences
+    }
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    ## Spaces not accounted for
+    put_data2 = [
+            {"sentenceId":100,
+             "draft": "ഒരു കാട്ടില്‍ ഒരു കുറുക്കന്‍ ജീവിച്ചിരുന്നു",
+             "draftMeta":[
+                  [ [3,4], [0,3], "confirmed"],
+                  [ [5,11], [4,11], "confirmed"],
+                  [ [32,33], [13,16], "confirmed"],
+                  [ [35,38], [18,26], "confirmed"]
+                ]
+            }
+    ]
+    resp = client.put(f"/v2/translation/project/draft?project_id={project_id}",
+        headers=headers_auth, json=put_data2)
+    assert resp.status_code == 422
+    assert "error" in resp.json()
+    assert resp.json()['error'] == "Unprocessable Data"

--- a/app/test/test_smast_translation2.py
+++ b/app/test/test_smast_translation2.py
@@ -87,9 +87,13 @@ def test_draft_update_positive():
              "draft": "ഒരു കാട്ടില്‍ ഒരു കുറുക്കന്‍ ജീവിച്ചിരുന്നു",
              "draftMeta":[
                   [ [3,4], [0,3], "confirmed"],
+                  [ [5,5], [3,4], "confirmed"],
                   [ [5,11], [4,11], "confirmed"],
+                  [ [11,11], [11,13], "confirmed"],
                   [ [32,33], [13,16], "confirmed"],
-                  [ [35,38], [18,26], "confirmed"]
+                  [ [33,33], [16,18], "confirmed"],
+                  [ [35,38], [18,26], "confirmed"],
+                  [ [38,38], [26,43], "untranslated"],
                 ]
             }
     ]
@@ -209,7 +213,7 @@ def test_draft_update_negative():
     resp = client.put(f"/v2/translation/project/draft?project_id={project_id}",
         headers=headers_auth, json=put_data2)
     assert resp.status_code == 422
-    assert resp.json()['details'] == "Incorrect metadata:Target segment (0, 10), is improper!"
+    assert resp.json()['details'] == "Incorrect metadata:Target segment [0, 10], is improper!"
 
 
 def test_empty_draft_initalization():
@@ -529,7 +533,46 @@ def test_suggestion_when_token_overlaps_confirmed_segment():
     # add a translation for just "not" when it occurs as "doesnot"
     update_draft_url = f"/v2/translation/project/draft?project_id={project_id}"
     data = [{ "draft": "they this",
-        "draftMeta": [ [ [ 0, 4 ], [ 9, 9 ], "untranslated" ], [ [ 4, 5 ], [ 9, 9 ], "untranslated" ], [ [ 5, 10 ], [ 9, 9 ], "untranslated" ], [ [ 10, 11 ], [ 9, 9 ], "untranslated" ], [ [ 11, 24 ], [ 9, 9 ], "untranslated" ], [ [ 24, 25 ], [ 9, 9 ], "untranslated" ], [ [ 25, 29 ], [ 9, 9 ], "untranslated" ], [ [ 29, 30 ], [ 9, 9 ], "untranslated" ], [ [ 30, 32 ], [ 9, 9 ], "untranslated" ], [ [ 32, 33 ], [ 9, 9 ], "untranslated" ], [ [ 33, 37 ], [ 9, 9 ], "untranslated" ], [ [ 37, 38 ], [ 9, 9 ], "untranslated" ], [ [ 38, 42 ], [ 9, 9 ], "untranslated" ], [ [ 42, 43 ], [ 9, 9 ], "untranslated" ], [ [ 43, 45 ], [ 9, 9 ], "untranslated" ], [ [ 45, 46 ], [ 9, 9 ], "untranslated" ], [ [ 46, 58 ], [ 9, 9 ], "untranslated" ], [ [ 58, 59 ], [ 9, 9 ], "untranslated" ], [ [ 59, 63 ], [ 9, 9 ], "untranslated" ], [ [ 63, 65 ], [ 9, 9 ], "untranslated" ], [ [ 65, 68 ], [ 9, 9 ], "untranslated" ], [ [ 68, 69 ], [ 9, 9 ], "untranslated" ], [ [ 69, 77 ], [ 9, 9 ], "untranslated" ], [ [ 77, 78 ], [ 9, 9 ], "untranslated" ], [ [ 78, 82 ], [ 9, 9 ], "untranslated" ], [ [ 82, 83 ], [ 9, 9 ], "untranslated" ], [ [ 83, 87 ], [ 9, 9 ], "untranslated" ], [ [ 87, 88 ], [ 9, 9 ], "untranslated" ], [ [ 88, 93 ], [ 9, 9 ], "untranslated" ], [ [ 93, 94 ], [ 9, 9 ], "untranslated" ], [ [ 94, 105 ], [ 9, 9 ], "untranslated" ], [ [ 105, 106 ], [ 9, 9 ], "untranslated" ], [ [ 106, 111 ], [ 9, 9 ], "untranslated" ], [ [ 111, 112 ], [ 9, 9 ], "untranslated" ], [ [ 112, 119 ], [ 9, 9 ], "untranslated" ], [ [ 119, 120 ], [ 9, 9 ], "untranslated" ], [ [ 132, 133 ], [ 9, 9 ], "untranslated" ], [ [ 125, 128 ], [ 5, 9 ], "confirmed" ], [ [ 129, 132 ], [ 0, 4 ], "confirmed" ] ],
+        "draftMeta": [ [ [ 0, 4 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 4, 5 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 5, 10 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 10, 11 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 11, 24 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 24, 25 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 25, 29 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 29, 30 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 30, 32 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 32, 33 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 33, 37 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 37, 38 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 38, 42 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 42, 43 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 43, 45 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 45, 46 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 46, 58 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 58, 59 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 59, 63 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 63, 65 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 65, 68 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 68, 69 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 69, 77 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 77, 78 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 78, 82 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 82, 83 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 83, 87 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 87, 88 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 88, 93 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 93, 94 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 94, 105 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 105, 106 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 106, 111 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 111, 112 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 112, 119 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 119, 120 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 132, 133 ], [ 9, 9 ], "untranslated" ],
+                       [ [ 125, 128 ], [ 5, 9 ], "confirmed" ],
+                       [ [ 129, 132 ], [ 0, 4 ], "confirmed" ],
+                       [ [ 125, 125 ], [ 4, 5 ], "confirmed" ] ],
         "sentenceId": 57001002 }]
     update_resp = client.put(update_draft_url,
                            json=data,
@@ -552,3 +595,35 @@ def test_suggestion_when_token_overlaps_confirmed_segment():
                                       'app':"SanketMAST"})
     assert suggest_resp.status_code == 201
 
+def test_draftmeta_validation():
+    '''All protions of the draft should have a draftmeta segment
+    issue #602'''
+    resp = add_project(project_data, auth_token=initial_test_users['AgUser']['token'])
+    assert resp.json()['message'] == "Project created successfully"
+    project_id = resp.json()['data']['projectId']
+
+    put_data = {
+        "projectId": project_id,
+        "sentenceList":source_sentences
+    }
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
+    resp = client.put("/v2/translation/projects", headers=headers_auth, json=put_data)
+    assert resp.json()['message'] == "Project updated successfully"
+
+    ## Spaces not accounted for
+    put_data2 = [
+            {"sentenceId":100,
+             "draft": "ഒരു കാട്ടില്‍ ഒരു കുറുക്കന്‍ ജീവിച്ചിരുന്നു",
+             "draftMeta":[
+                  [ [3,4], [0,3], "confirmed"],
+                  [ [5,11], [4,11], "confirmed"],
+                  [ [32,33], [13,16], "confirmed"],
+                  [ [35,38], [18,26], "confirmed"]
+                ]
+            }
+    ]
+    resp = client.put(f"/v2/translation/project/draft?project_id={project_id}",
+        headers=headers_auth, json=put_data2)
+    assert resp.status_code == 422
+    assert "error" in resp.json()
+    assert resp.json()['error'] == "Unprocessable Data"


### PR DESCRIPTION
- Investigating #602 
- Found that the draft meta updated did not have status and alignment specified for space in it. Adding the segment for space would fix the issue
- Added validation to check all portions of draft have corresponding draftMeta provided
- Moved this validation function to utils sub module to be able to import and use from different places.
- Applying the same validation on the input draftMeta recieved and also the output draftMeta generated after token-replacement and suggestions
- Added test for the new bug, ensuring it give proper error message
- Also updated few older tests which were not adding segments for spaces