### PR TITLE
Use CICD bot's account to push upon bump version

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -32,8 +32,9 @@ jobs:
       - name: Move release tag to latest commit
         run: |
           git tag -a $(git describe --tags --abbrev=0) -m "moving tag to new commit" -f $(git rev-parse HEAD)
-          git config --global user.name 'Gitactions bot'
-          git config --global user.email '<>'
+          git config --global user.name "${{ secrets.CICD_BOT_USER }}"
+          git config --global user.email "${{ secrets.CICD_BOT_EMAIL }}"
+          git config --global user.password "${{ secrets.CICD_BOT_PASS }}"
           git push -f origin refs/tags/$(git describe --tags --abbrev=0)
 
   pull-n-deploy:


### PR DESCRIPTION
- In connection with #540 
- The push to the protected branch, version-2, was denied when run on bridgeconn repo
- Now using a bot user with privileged rights