### PR TITLE
Fix cicd bot's push rights to version-2: trail #1

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -22,19 +22,17 @@ jobs:
           head -n 33 app/main.py | tail -n 4
 
       - name: Commit changes
-        uses: EndBug/add-and-commit@v9
-        with:
-          default_author: github_actor
-          message: 'Bump version automatically on release'
-          add: './app/main.py'
-          push: 'origin HEAD:version-2 --force'
+        run: |
+          git config --global user.name "${{ secrets.CICD_BOT_USER }}"
+          git config --global user.email "${{ secrets.CICD_BOT_EMAIL }}"
+          git config --global user.password "${{ secrets.CICD_BOT_PASS }}"
+          git add ./app/main.py
+          git commit -m 'Bump version automatically on release'
+          git push -f origin version-2
 
       - name: Move release tag to latest commit
         run: |
           git tag -a $(git describe --tags --abbrev=0) -m "moving tag to new commit" -f $(git rev-parse HEAD)
-          git config --global user.name "${{ secrets.CICD_BOT_USER }}"
-          git config --global user.email "${{ secrets.CICD_BOT_EMAIL }}"
-          git config --global user.password "${{ secrets.CICD_BOT_PASS }}"
           git push -f origin refs/tags/$(git describe --tags --abbrev=0)
 
   pull-n-deploy:


### PR DESCRIPTION
- Attempt to fix the bot being not able to push to the protected branch, vesrion-2
- In connection with #540 