### PR TITLE
Fix cicd bot's push rights to version-2: trail #2

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -28,7 +28,7 @@ jobs:
           git config --global user.password "${{ secrets.CICD_BOT_PASS }}"
           git add ./app/main.py
           git commit -m 'Bump version automatically on release'
-          git push -f origin version-2
+          git push -f origin HEAD:version-2
 
       - name: Move release tag to latest commit
         run: |


### PR DESCRIPTION
- Attempt to fix ci-cd bot's push rights to the protected version-2 branch
- In connection with #540 