### PR TITLE
Removing the link between text bibles and audio bibles

### DIFF
--- a/app/auth/api-permissions.csv
+++ b/app/auth/api-permissions.csv
@@ -116,6 +116,15 @@ Endpoints,Method,RequestApp,FilterResults,ResourceType,Permission
 /v2/resources/parascripturals/{resource_name},POST,None,False,None,create
 /v2/resources/parascripturals/{resource_name},PUT,None,False,None,edit
 /v2/resources/parascripturals/{resource_name},DELETE,None,False,None,delete/deactivate
+/v2/resources/bible/audios/{resource_name},GET,Autographa,False,None,refer-for-translation
+/v2/resources/bible/audios/{resource_name},GET,SanketMAST,False,None,refer-for-translation
+/v2/resources/bible/audios/{resource_name},GET,Vachan-online or vachan-app,False,None,view-on-web
+/v2/resources/bible/audios/{resource_name},GET,VachanAdmin,False,None,read-via-vachanadmin
+/v2/resources/bible/audios/{resource_name},GET,VachanContentDashboard,False,None,read-via-vachancontentdashboard
+/v2/resources/bible/audios/{resource_name},GET,API-user,False,None,read-via-api
+/v2/resources/bible/audios/{resource_name},POST,None,False,None,create
+/v2/resources/bible/audios/{resource_name},PUT,None,False,None,edit
+/v2/resources/bible/audios/{resource_name},DELETE,None,False,None,delete/deactivate
 /v2/resources/bible/videos/{resource_name},GET,Autographa,False,None,refer-for-translation
 /v2/resources/bible/videos/{resource_name},GET,SanketMAST,False,None,refer-for-translation
 /v2/resources/bible/videos/{resource_name},GET,Vachan-online or vachan-app,False,None,view-on-web

--- a/app/auth/api-permissions.csv
+++ b/app/auth/api-permissions.csv
@@ -80,9 +80,6 @@ Endpoints,Method,RequestApp,FilterResults,ResourceType,Permission
 /v2/bibles/{resource_name}/verses,GET,VachanAdmin,False,None,read-via-vachanadmin
 /v2/bibles/{resource_name}/verses,GET,VachanContentDashboard,False,None,read-via-vachancontentdashboard
 /v2/bibles/{resource_name}/verses,GET,API-user,False,None,read-via-api
-/v2/bibles/{resource_name}/audios,POST,None,False,None,create
-/v2/bibles/{resource_name}/audios,PUT,None,False,None,edit
-/v2/bibles/{resource_name}/audios,DELETE,None,False,None,delete/deactivate
 /v2/commentaries/{resource_name},GET,Autographa,False,None,refer-for-translation
 /v2/commentaries/{resource_name},GET,SanketMAST,False,None,refer-for-translation
 /v2/commentaries/{resource_name},GET,Vachan-online or vachan-app,False,None,view-on-web

--- a/app/crud/contents_crud.py
+++ b/app/crud/contents_crud.py
@@ -604,7 +604,7 @@ def upload_audio_bible(db_: Session, resource_name, audiobibles, user_id=None):
         raise NotAvailableException(f'Resource {resource_name}, not found in database')
     if resource_db_content.contentType.contentType != \
         db_models.ContentTypeName.AUDIOBIBLE.value:
-        raise TypeException('The operation is supported only on sign bible videos')
+        raise TypeException('The operation is supported only on audio bibles')
     model_cls = db_models.dynamicTables[resource_name]
     db_content = []
     for item in audiobibles:
@@ -661,7 +661,7 @@ def update_audio_bible(db_: Session, resource_name, audiobibles, user_id=None): 
         raise NotAvailableException(f'Resource {resource_name}, not found in database')
     if resource_db_content.contentType.contentType != \
         db_models.ContentTypeName.AUDIOBIBLE.value:
-        raise TypeException('The operation is supported only on sign bible videos')
+        raise TypeException('The operation is supported only on audio bibles')
     model_cls = db_models.dynamicTables[resource_name]
     db_content = []
     for item in audiobibles:

--- a/app/crud/contents_crud.py
+++ b/app/crud/contents_crud.py
@@ -5,7 +5,6 @@ import json
 import re
 from datetime import datetime
 from pytz import timezone
-import sqlalchemy
 from sqlalchemy.orm import Session, defer, joinedload
 from sqlalchemy.sql import text
 import db_models #pylint: disable=import-error
@@ -543,6 +542,189 @@ def delete_parascriptural(db_: Session, delitem: int,table_name = None,\
         }
     return response
 
+def get_audio_bible(db_:Session, resource_name, name=None,**kwargs): #pylint: disable=too-many-locals
+    '''Fetches rows of audio bibles from the table specified by resource_name'''
+    audio_format = kwargs.get("audio_format",None)
+    search_word = kwargs.get("search_word",None)
+    reference = kwargs.get("reference",None)
+    link = kwargs.get("link",None)
+    metadata = kwargs.get("metadata",None)
+    active = kwargs.get("active",True)
+    skip = kwargs.get("skip",0)
+    limit = kwargs.get("limit",100)
+    audio_id=kwargs.get("audio_id",None)
+    if resource_name not in db_models.dynamicTables:
+        raise NotAvailableException(f'{resource_name} not found in database.')
+    if not resource_name.endswith(db_models.ContentTypeName.AUDIOBIBLE.value):
+        raise TypeException('The operation is supported only on audio bibles')
+    model_cls = db_models.dynamicTables[resource_name]
+    query = db_.query(model_cls)
+    if name:
+        query = query.filter(model_cls.name == utils.normalize_unicode(name.strip()))
+    if  audio_format:
+        query = query.filter(model_cls.audioFormat.contains(
+            utils.normalize_unicode(audio_format.strip())))
+    if link:
+        query = query.filter(model_cls.link == link)
+    if audio_id:
+        query = query.filter(model_cls.audioId == audio_id)
+    if reference:
+        query = filter_by_reference(db_,query, model_cls, reference)
+    if metadata:
+        meta = json.loads(metadata)
+        for key in meta:
+            key_match = db_models.AudioBible.metaData.op('->>')(key).ilike(f'%{key}%')
+            value_match = db_models.AudioBible.metaData.op('->>')(key).ilike(f'%{meta[key]}%')
+            query = query.filter(key_match | value_match)
+    if search_word:
+        search_pattern = " & ".join(re.findall(r'\w+', search_word))
+        search_pattern += ":*"
+        query = query.filter(text(
+            "to_tsvector('simple', name || ' ' || audio_id || " +
+            "' ' || audio_format || ' ' || link || ' ' || " +
+            "jsonb_to_tsvector('simple', reference, '[\"string\", \"numeric\"]') || ' ' || " +
+            "jsonb_to_tsvector('simple', metadata, '[\"string\", \"numeric\"]') " +
+            ") @@ to_tsquery('simple', :pattern)"
+        ).bindparams(pattern=search_pattern))
+
+    query = query.filter(model_cls.active == active)
+    resource_db_content = db_.query(db_models.Resource).filter(
+        db_models.Resource.resourceName == resource_name).first()
+    response = {
+        'db_content':query.offset(skip).limit(limit).all(),
+        'resource_content':resource_db_content
+        }
+    return response
+
+def upload_audio_bible(db_: Session, resource_name, audiobibles, user_id=None):
+    '''Adds rows to the audio bibles table specified by resource_name'''
+    resource_db_content = db_.query(db_models.Resource).filter(
+        db_models.Resource.resourceName == resource_name).first()
+    if not resource_db_content:
+        raise NotAvailableException(f'Resource {resource_name}, not found in database')
+    if resource_db_content.contentType.contentType != \
+        db_models.ContentTypeName.AUDIOBIBLE.value:
+        raise TypeException('The operation is supported only on sign bible videos')
+    model_cls = db_models.dynamicTables[resource_name]
+    db_content = []
+    for item in audiobibles:
+        if item.reference:
+            ref = item.reference.__dict__
+            if ref['verseNumber'] is not None:
+                ref_start = utils.create_decimal_ref_id(
+                    db_,ref['book'],ref['chapter'],ref['verseNumber'])
+            else:
+                #setting verseNumber to 000 if its not present
+                ref_start = utils.create_decimal_ref_id(db_,ref['book'],ref['chapter'],0)
+                ref['verseNumber'] = 0
+            if ref['verseEnd'] is not None:
+                ref_end   = utils.create_decimal_ref_id(
+                    db_,ref['bookEnd'],ref['chapterEnd'],ref['verseEnd'])
+            else:
+                #setting verseEnd to 999 if its not present
+                ref_end   = utils.create_decimal_ref_id(db_,ref['bookEnd'],ref['chapterEnd'],999)
+                ref['verseEnd'] = 999
+        else:
+            ref = None
+            ref_end = None
+            ref_start = None
+        if item.name:
+            item.name = utils.normalize_unicode(item.name.strip())
+        if item.audioFormat:
+            item.audioFormat = utils.normalize_unicode(item.audioFormat.strip())
+        row = model_cls(
+            name = item.name,
+            audioFormat =item.audioFormat,
+            reference = ref,
+            refStart=ref_start,
+            refEnd=ref_end,
+            link = item.link,
+            metaData = item.metaData,
+            active = item.active,
+            createdUser =  user_id)
+        db_content.append(row)
+    db_.add_all(db_content)
+    db_.expire_all()
+    resource_db_content.updatedUser = user_id
+    response = {
+        'db_content':db_content,
+        'resource_content':resource_db_content
+        }
+    return response
+
+def update_audio_bible(db_: Session, resource_name, audiobibles, user_id=None): #pylint: disable=too-many-branches
+    '''Update rows, that matches audioId in the audio bibles table
+    specified by resource_name'''
+    resource_db_content = db_.query(db_models.Resource).filter(
+        db_models.Resource.resourceName == resource_name).first()
+    if not resource_db_content:
+        raise NotAvailableException(f'Resource {resource_name}, not found in database')
+    if resource_db_content.contentType.contentType != \
+        db_models.ContentTypeName.AUDIOBIBLE.value:
+        raise TypeException('The operation is supported only on sign bible videos')
+    model_cls = db_models.dynamicTables[resource_name]
+    db_content = []
+    for item in audiobibles:
+        row = db_.query(model_cls).filter(
+            model_cls.audioId == item.audioId).first()
+        if not row:
+            raise NotAvailableException(f"AUdio Bible row with id:{item.audioId}, "+\
+                f"not found for {resource_name}")
+        if item.name:
+            item.name = utils.normalize_unicode(item.name.strip())
+            row.name = item.name
+        if item.audioFormat:
+            item.audioFormat = utils.normalize_unicode(item.audioFormat.strip())
+            row.audioFormat = item.audioFormat
+        if item.link:
+            row.link = item.link
+        if item.reference:
+            ref = item.reference.__dict__
+            if ref['verseNumber'] is not None:
+                ref_start = utils.create_decimal_ref_id(
+                    db_,ref['book'],ref['chapter'],ref['verseNumber'])
+            else:
+                ref_start = utils.create_decimal_ref_id(db_,ref['book'],ref['chapter'],0)
+            if ref['verseEnd'] is not None:
+                ref_end   = utils.create_decimal_ref_id(
+                    db_,ref['bookEnd'],ref['chapterEnd'],ref['verseEnd'])
+            else:
+                ref_end   = utils.create_decimal_ref_id(db_,ref['bookEnd'],ref['chapterEnd'],999)
+            row.reference = ref
+            row.refStart=ref_start
+            row.refEnd=ref_end
+        if item.metaData:
+            row.metaData = item.metaData
+        if item.active is not None:
+            row.active = item.active
+        db_.flush()
+        db_content.append(row)
+    resource_db_content.updatedUser = user_id
+    resource_db_content.updateTime = datetime.now(ist_timezone).strftime('%Y-%m-%d %H:%M:%S')
+    response = {
+        'db_content':db_content,
+        'resource_content':resource_db_content
+        }
+    return response
+
+def delete_audio_bible(db_: Session, delitem: int,table_name = None,\
+    resource_name=None,user_id=None):
+    '''delete particular item from audio bibles, selected via resourceName and audio id'''
+    resource_db_content = db_.query(db_models.Resource).filter(
+        db_models.Resource.resourceName == resource_name).first()
+    model_cls = table_name
+    query = db_.query(model_cls)
+    db_content = query.filter(model_cls.audioId == delitem).first()
+    db_.flush()
+    db_.delete(db_content)
+    #db_.commit()
+    resource_db_content.updatedUser = user_id
+    response = {
+        'db_content':db_content,
+        'resource_content':resource_db_content
+        }
+    return response
+
 def get_sign_bible_videos(db_:Session, resource_name, title=None,**kwargs): #pylint: disable=too-many-locals
     '''Fetches rows of sign bible videos from the table specified by resource_name'''
     description = kwargs.get("description",None)
@@ -998,104 +1180,6 @@ def update_bible_books_cleaned(db_,resource_name,books,resource_db_content,user_
     return resource_db_content
     # db_.commit()
 
-def upload_bible_audios(db_:Session, resource_name, audios, user_id=None):
-    '''Add audio bible related contents to _bible_audio table'''
-    resource_db_content = db_.query(db_models.Resource).filter(
-        db_models.Resource.resourceName == resource_name).first()
-    if not resource_db_content:
-        raise NotAvailableException(f'Resource {resource_name}, not found in database')
-    if resource_db_content.contentType.contentType != 'bible':
-        raise TypeException('The operation is supported only on bible')
-    model_cls_audio = db_models.dynamicTables[resource_name+'_audio']
-    model_cls_bible = db_models.dynamicTables[resource_name]
-    db_content = []
-    db_content2 = []
-    for item in audios:
-        for buk in item.books:
-            book = db_.query(db_models.BibleBook).filter(
-                db_models.BibleBook.bookCode == buk.strip().lower()).first()
-            if not book:
-                raise NotAvailableException(f'Bible Book code, {buk}, not found in database')
-            bible_table_row = db_.query(model_cls_bible).filter(
-                model_cls_bible.book_id == book.bookId).first()
-            if not bible_table_row:
-                bible_table_row = model_cls_bible(
-                    book_id=book.bookId
-                    )
-                db_content2.append(bible_table_row)
-            row = model_cls_audio(
-                name=utils.normalize_unicode(item.name.strip()),
-                url=item.url.strip(),
-                book_id=book.bookId,
-                format=item.format.strip(),
-                active=item.active)
-            db_content.append(row)
-    db_.add_all(db_content)
-    db_.add_all(db_content2)
-    resource_db_content.updatedUser = user_id
-    # db_.commit()
-    response = {
-        'db_content':db_content,
-        'resource_content':resource_db_content
-    }
-    # return db_content
-    return response
-
-def update_bible_audios(db_: Session, resource_name, audios, user_id=None):
-    '''Update any details of a bible Auido row.
-    Use name as row-identifier, which cannot be changed'''
-    resource_db_content = db_.query(db_models.Resource).filter(
-        db_models.Resource.resourceName == resource_name).first()
-    if not resource_db_content:
-        raise NotAvailableException(f'Resource {resource_name}, not found in database')
-    if resource_db_content.contentType.contentType != 'bible':
-        raise TypeException('The operation is supported only on bible')
-    model_cls = db_models.dynamicTables[resource_name+'_audio']
-    db_content = []
-    for item in audios:
-        for buk in item.books:
-            book = db_.query(db_models.BibleBook).filter(
-                db_models.BibleBook.bookCode == buk.strip().lower()).first()
-            if not book:
-                raise NotAvailableException(f'Bible Book code, {buk}, not found in database')
-            row = db_.query(model_cls).filter(model_cls.book_id == book.bookId).first()
-            if not row:
-                raise NotAvailableException(f"Bible audio for, {item.name}, not found in database")
-            if item.name:
-                row.name = utils.normalize_unicode(item.name.strip())
-            if item.url:
-                row.url = item.url.strip()
-            if item.format:
-                row.format = item.format.strip()
-            if item.active is not None:
-                row.active = item.active
-            db_content.append(row)
-    resource_db_content.updatedUser = user_id
-    # db_.commit()
-    # return db_content
-    response = {
-        'db_content':db_content,
-        'resource_content':resource_db_content
-        }
-    return response
-
-def delete_bible_audio(db_: Session, delitem: int,\
-    resource_name=None,user_id=None):
-    '''delete particular item from bible audio, selected via resourcename and bible audio id'''
-    resource_db_content = db_.query(db_models.Resource).filter(
-        db_models.Resource.resourceName == resource_name).first()
-    model_cls =  db_models.dynamicTables[resource_name+'_audio']
-    query = db_.query(model_cls)
-    db_content = query.filter(model_cls.audioId == delitem).first()
-    db_.flush()
-    db_.delete(db_content)
-    #db_.commit()
-    resource_db_content.updatedUser = user_id
-    response = {
-        'db_content'    :db_content,
-        'resource_content':resource_db_content
-        }
-    return response
 
 def get_bible_versification(db_, resource_name):
     '''select the reference list from bible_cleaned table'''
@@ -1142,20 +1226,15 @@ def get_available_bible_books(db_, resource_name,book_code=None, content_type=No
     active = kwargs.get("active",True)
     skip = kwargs.get("skip",0)
     limit = kwargs.get("limit",100)
-    bibleaudio_id = kwargs.get("bibleaudio_id",None)
     if resource_name not in db_models.dynamicTables:
         raise NotAvailableException(f'{resource_name} not found in database.')
     if not resource_name.endswith('_bible'):
         raise TypeException('The operation is supported only on bible')
     model_cls = db_models.dynamicTables[resource_name]
-    model_cls_audio = db_models.dynamicTables[resource_name+"_audio"]
-    query = db_.query(model_cls).outerjoin(model_cls_audio, model_cls_audio.book_id ==
-        model_cls.book_id).options(joinedload(model_cls.book))
+    query = db_.query(model_cls).options(joinedload(model_cls.book))
     fetched = None
     if biblecontent_id:
         query = query.filter(model_cls.bookContentId  == biblecontent_id)
-    if bibleaudio_id:
-        query = query.filter(model_cls_audio.audioId  == bibleaudio_id)
     if book_code:
         query = query.filter(model_cls.book.has(bookCode=book_code.lower()))
     if content_type == "usfm":
@@ -1163,13 +1242,7 @@ def get_available_bible_books(db_, resource_name,book_code=None, content_type=No
     elif content_type == "json":
         query = query.options(defer(model_cls.USFM))
     elif content_type == "all":
-        query = query.options(joinedload(model_cls.audio)).filter(
-            sqlalchemy.or_(model_cls.active == active, model_cls.audio.has(active=active)))
-        fetched = query.offset(skip).limit(limit).all()
-    elif content_type == "audio":
-        query = query.options(joinedload(model_cls.audio),
-            defer(model_cls.JSON), defer(model_cls.USFM)).filter(
-            model_cls.audio.has(active=active))
+        query = query.filter(model_cls.active == active)
         fetched = query.offset(skip).limit(limit).all()
     elif content_type is None:
         query = query.options(defer(model_cls.JSON), defer(model_cls.USFM))

--- a/app/crud/structurals_crud.py
+++ b/app/crud/structurals_crud.py
@@ -168,20 +168,18 @@ def restore_data(db_: Session, restored_item :schemas.RestoreIdentity):
     if db_restore.deletedFrom in content_class_map:
         model_cls = content_class_map[db_restore.deletedFrom]
     else:
-        if db_restore.deletedFrom.endswith("audio"):
-            renamed_table = db_restore.deletedFrom.replace("_audio", "")
-            if not  get_resources(db_, table_name = renamed_table):
-                raise NotAvailableException('Resource not found in database')
-        elif db_restore.deletedFrom.endswith("cleaned"):
+        if db_restore.deletedFrom.endswith("cleaned"):
             renamed_table = db_restore.deletedFrom.replace("_cleaned", "")
             if not  get_resources(db_, table_name = renamed_table):
                 raise NotAvailableException('Resource not found in database')
-        if db_restore.deletedFrom.endswith(("audio","cleaned")) is False:
+        if db_restore.deletedFrom.endswith(("cleaned")) is False:
             if not  get_resources(db_, table_name=db_restore.deletedFrom):
                 raise NotAvailableException('Resource not found in database')
             resource = get_resources(db_, table_name=db_restore.deletedFrom)[0]
             resource_name = resource.resourceName
-            if resource_name.endswith("bible") is False:
+            if resource_name.endswith("audiobible") is True:
+                model_cls = db_models.dynamicTables[resource.resourceName]
+            elif resource_name.endswith("bible") is False:
                 model_cls = db_models.dynamicTables[resource.resourceName]
             else:
                 model_cls = db_models.dynamicTables[resource.resourceName]
@@ -195,10 +193,6 @@ def restore_data(db_: Session, restored_item :schemas.RestoreIdentity):
                 db_content2 = utils.convert_dict_to_sqlalchemy(json_string2, model_cls2)
                 db_.add(db_content2)
                 db_.delete(db_restore2)
-        else:
-            resource_table = db_restore.deletedFrom.replace("_audio", "")
-            resource = get_resources(db_, table_name=resource_table)[0]
-            model_cls = db_models.dynamicTables[resource.resourceName+'_audio']
     db_content = utils.convert_dict_to_sqlalchemy(json_string, model_cls)
     db_.add(db_content)
     db_.delete(db_restore)
@@ -498,9 +492,6 @@ def create_resource(db_: Session, resource: schemas.ResourceCreate, user_id):
         db_models.dynamicTables[db_content.resourceName+'_cleaned'].__table__.create(
             bind=engine, checkfirst=True)
         log.warning("User %s, creates a new table %s", user_id, db_content.resourceName+'_cleaned')
-        db_models.dynamicTables[db_content.resourceName+'_audio'].__table__.create(
-            bind=engine, checkfirst=True)
-        log.warning("User %s, creates a new table %s", user_id, db_content.resourceName+'_audio')
     log.warning("User %s, creates a new table %s", user_id, db_content.resourceName)
     # db_.commit()
     # db_.refresh(db_content)
@@ -577,8 +568,6 @@ def update_resource(db_: Session, resource: schemas.ResourceEdit, user_id = None
         if resource.resourceName.split("_")[-1] == 'bible':
             db_models.dynamicTables[db_content.resourceName+'_cleaned'] = \
                 db_models.dynamicTables[resource.resourceName+'_cleaned']
-            db_models.dynamicTables[db_content.resourceName+'_audio'] = \
-                db_models.dynamicTables[resource.resourceName+'_audio']
     return db_content
 
 def delete_resource(db_: Session, delitem: int):

--- a/app/db_models.py
+++ b/app/db_models.py
@@ -27,6 +27,7 @@ class ContentTypeName(Enum):
     PARASCRIPTURAL = "parascriptural"
     VOCABULARY = "vocabulary"
     GITLABREPO = "gitlabrepo"
+    AUDIOBIBLE = "audiobible"
     SIGNBIBLEVIDEO = "signbiblevideo"
 
 class TranslationDocumentType(Enum):
@@ -204,19 +205,22 @@ class SignBibleVideo():# pylint: disable=too-few-public-methods
     __table_args__ = (
         {'extend_existing': True}
                      )
-class BibleAudio(): # pylint: disable=too-few-public-methods
+class AudioBible(): # pylint: disable=too-few-public-methods
     '''Corresponds to the dynamically created bible_audio tables in vachan Db(postgres)'''
-    audioId  = Column('bible_audio_id', Integer,
-        Sequence('bible_audio_id_seq', start=100001, increment=1), primary_key=True)
+    audioId  = Column('audio_id', Integer,
+        Sequence('audio_id_seq', start=100001, increment=1), primary_key=True)
     name = Column('name', String)
-    @declared_attr
-    def book_id(self):
-        '''FK column referncing bible contents'''
-        table_name = self.__tablename__.replace("_audio", "") #pylint: disable=E1101
-        return Column('book_id', Integer, ForeignKey(table_name+'.book_id'), unique=True)
-    url = Column('audio_link', String)
-    format = Column('audio_format', String)
-    active = Column('active', Boolean, default=True)
+    reference = Column('reference', JSONB)
+    refStart = Column('ref_start', Integer)
+    refEnd = Column('ref_end', Integer)
+    link = Column('link', String)
+    audioFormat = Column('audio_format', String)
+    metaData = Column('metadata', JSONB)
+    active = Column('active', Boolean)
+    createdUser = Column('created_user', String)
+    updatedUser = Column('last_updated_user', String)
+    createTime = Column('created_at', DateTime, default=ist_time)
+    updateTime = Column('last_updated_at', DateTime, onupdate= ist_time,default=ist_time)
     __table_args__ = {'extend_existing': True}
 
 class BibleContent(): # pylint: disable=too-few-public-methods
@@ -232,12 +236,6 @@ class BibleContent(): # pylint: disable=too-few-public-methods
         return relationship(BibleBook, uselist=False)
     USFM = Column('usfm', String)
     JSON = Column('json_object', JSON)
-    @declared_attr
-    def audio(self): # pylint: disable=E0213
-        '''For modelling the audio field in bible content classes'''
-        refering_table = self.__tablename__+"_audio" #pylint: disable=E1101
-        # return relationship(dynamicTables[refering_table], uselist=False)
-        return relationship(refering_table, uselist=False)
     active = Column('active', Boolean, default=True)
     __table_args__ = {'extend_existing': True}
 
@@ -283,9 +281,6 @@ class BibleContentCleaned(): # pylint: disable=too-few-public-methods
 def create_dynamic_table(resource_name, table_name, content_type):
     '''To map or create one dynamic table based on the content Type'''
     if content_type == ContentTypeName.BIBLE.value:
-        dynamicTables[resource_name+'_audio'] = type(
-            table_name+'_audio',(BibleAudio, Base,),
-            {"__tablename__": table_name+'_audio'})
         dynamicTables[resource_name] = type(
             table_name,(BibleContent, Base,),
             {"__tablename__": table_name})
@@ -306,6 +301,9 @@ def create_dynamic_table(resource_name, table_name, content_type):
     elif content_type == ContentTypeName.PARASCRIPTURAL.value:
         dynamicTables[resource_name] = type(
             table_name,(Parascriptural, Base,),{"__tablename__": table_name})
+    elif content_type == ContentTypeName.AUDIOBIBLE.value:
+        dynamicTables[resource_name] = type(
+            table_name,(AudioBible, Base,),{"__tablename__": table_name})
     elif content_type == ContentTypeName.SIGNBIBLEVIDEO.value:
         dynamicTables[resource_name] = type(
             table_name,(SignBibleVideo, Base,),{"__tablename__": table_name})

--- a/app/schema/schema_content.py
+++ b/app/schema/schema_content.py
@@ -25,75 +25,6 @@ class BibleBook(BaseModel):
             }
         }
 
-class AudioBible(BaseModel):
-    '''Response object of Audio Bible'''
-    audioId: int
-    name: str = None
-    url: AnyUrl = None
-    # book:  BibleBook
-    format: str = None
-    active: bool = None
-    class Config:
-        ''' telling Pydantic that "it's OK if I pass a non-dict value'''
-        orm_mode = True
-        # '''display example value in API documentation'''
-        schema_extra = {
-            "example": {
-                "name": "XXX audio bible: Gospel series",
-                "url": "http://someplace.come/resoucesid",
-                "format": "mp3",
-                "active": True
-            }
-        }
-
-class AudioBibleCreateResponse(BaseModel):
-    '''Response object of auido bible update'''
-    message: str = Field(..., example="Bible audios details uploaded successfully")
-    data: List[AudioBible] = None
-
-class AudioBibleUpdateResponse(BaseModel):
-    '''Response object of auido bible update'''
-    message: str = Field(..., example="Bible audios details updated successfully")
-    data: List[AudioBible] = None
-
-class AudioBibleUpload(BaseModel):
-    '''Input object of Audio Bible'''
-    name: str
-    url: AnyUrl
-    books:  List[BookCodePattern]
-    format: str
-    active: bool = True
-    class Config:
-        '''display example value in API documentation'''
-        schema_extra = {
-            "example": {
-                "name": "XXX audio bible: Gospel series",
-                "books": ["mat"],
-                "url": "http://someplace.come/resoucesid",
-                "format": "mp3",
-                "active": True
-            }
-        }
-
-class AudioBibleEdit(BaseModel):
-    ''' Input object of Auido Bible'''
-    name: str = None
-    url: AnyUrl = None
-    books: List[BookCodePattern]
-    format: str = None
-    active: bool = None
-    class Config:
-        '''display example value in API documentation'''
-        schema_extra = {
-            "example": {
-                "books": ["mat", "mrk", "luk", "jhn"],
-                "name": "XXX audio bible: Gospel series",
-                "url": "http://someplace.come/resoucesid",
-                "format": "mp3",
-                "active": True
-            }
-        }
-
 class Reference(BaseModel):
     '''Response object of parascript reference'''
     bible : TableNamePattern = None
@@ -154,7 +85,6 @@ class BibleBookContent(BaseModel):
     bookName: str = None
     USFM: str = None
     JSON: dict = None
-    audio: AudioBible = None
     active: bool
     class Config:
         ''' telling Pydantic that "it's OK if I pass a non-dict value'''
@@ -174,12 +104,6 @@ class BibleBookContent(BaseModel):
                  "verseText": "इब्राहीम की सन्‍तान, दाऊद की ..."}]}
                         ]
                     },
-                "AudioBible": {
-                    "name": "XXX audio bible: Gospel series",
-                    "url": "http://someplace.come/resoucesid",
-                    "format": "mp3",
-                    "active": True
-                },
                 "active": True
             }
         }
@@ -605,6 +529,85 @@ class ParascripturalCreate(BaseModel):
             }
         }
 
+class AudioBibleResponse(BaseModel):
+    '''Response object of audio bibles'''
+    audioId : int
+    name: str = None
+    audioFormat: str = None
+    reference: Reference = None
+    link: AnyUrl = None
+    metaData: dict = None
+    active: bool = None
+    class Config:
+        ''' telling Pydantic that "it's OK if I pass a non-dict value'''
+        orm_mode = True
+        # '''display example value in API documentation'''
+        schema_extra = {
+            "example": {
+                "audioId": 100001,
+                "name": "audio bible: Gospel series",
+                "audioFormat": "mp3",
+                "reference": {"book":"GEN", "chapter":1, "verseNumber":1,
+                               "bookEnd":"GEN", "chapterEnd":10, "verseEnd":10 },
+                "link": "http://someplace.com/resoucesid",
+                "metaData": {"othername": "Word of God"},
+                "active": True
+            }
+        }
+class AudioBibleEdit(BaseModel):
+    '''Input object of audio bibles update'''
+    audioId: int
+    name: str = None
+    audioFormat: str = None
+    reference: Reference = None
+    link: AnyUrl = None
+    active: bool = None
+    metaData: dict = None
+    class Config:
+        '''display example value in API documentation'''
+        schema_extra = {
+            "example": {
+                "audioId":100001,
+                "name": "audio bible: Origin",
+                "audioFormat": "mp3",
+                "reference": {"book":"MAT", "chapter":2, "verseNumber":10,
+                               "bookEnd":"MAT", "chapterEnd":12, "verseEnd":15 },
+                "link": "http://someplace.com/newresoucesid",
+                "metaData": {"othername": "origin of world"},
+                "active": True
+            }
+        }
+class AudioBibleUpdateResponse(BaseModel):
+    '''Response object of audio bibles update'''
+    message: str = Field(..., example="Audio Bible updated successfully")
+    data: List[AudioBibleResponse] = None
+
+class AudioBibleCreateResponse(BaseModel):
+    '''Response object of audio bibles update'''
+    message: str = Field(..., example="Audio Bible added successfully")
+    data: List[AudioBibleResponse] = None
+
+class AudioBibleCreate(BaseModel):
+    '''Input object for sign bible video'''
+    name: str
+    audioFormat: str = None
+    reference: Reference = None
+    link: AnyUrl = None
+    metaData: dict = None
+    active: bool = True
+    class Config:
+        '''display example value in API documentation'''
+        schema_extra = {
+            "example": {
+                "name": "audio bible: Gospel series",
+                "audioFormat": "mp3",
+                "reference": {"book":"GEN", "chapter":1, "verseNumber":1,
+                               "bookEnd":"GEN", "chapterEnd":10, "verseEnd":10 },
+                "link": "http://someplace.com/resoucesid",
+                "metaData": {"othername": "Word of God"},
+                "active": True
+            }
+        }
 class SignVideoResponse(BaseModel):
     '''Response object of sign bible videos'''
     signVideoId : int

--- a/app/test/test_bible_audios.py
+++ b/app/test/test_bible_audios.py
@@ -1,4 +1,4 @@
-'''Test cases for parascripturals related APIs'''
+'''Test cases for bible audios related APIs'''
 from . import client , contetapi_get_accessrule_checks_app_userroles
 from . import check_default_get
 from . import assert_input_validation_error, assert_not_available_content
@@ -7,7 +7,7 @@ from .test_resources import check_post as add_resource
 from . test_auth_basic import login,SUPER_PASSWORD,SUPER_USER,logout_user
 from .conftest import initial_test_users
 
-UNIT_URL = '/v2/resources/parascripturals/'
+UNIT_URL = '/v2/resources/bible/audios/'
 RESOURCE_URL = '/v2/resources'
 RESTORE_URL = '/v2/restore'
 headers = {"contentType": "application/json", "accept": "application/json"}
@@ -16,22 +16,20 @@ headers_auth = {"contentType": "application/json",
 
 def assert_positive_get(item):
     '''Check for the properties in the normal return object'''
-    assert "parascriptId" in item
-    assert isinstance(item['parascriptId'], int)
-    assert "category" in item
-    assert "title" in item
+    assert "audioId" in item
+    assert isinstance(item['audioId'], int)
     assert "active" in item
 
 def check_post(data: list):
     '''prior steps and post attempt, without checking the response'''
     version_data = {
         "versionAbbreviation": "TTT",
-        "versionName": "test version for parascriptural",
+        "versionName": "test version for audiobible",
     }
     add_version(version_data)
     resource_data = {
-        "contentType": "parascriptural",
-        "language": "ur",
+        "contentType": "audiobible",
+        "language": "ins",
         "version": "TTT",
         "year": 2020,
         "versionTag": 1
@@ -52,81 +50,53 @@ def check_post(data: list):
     return response, resource_name
 
 def test_post_default():
-    '''Positive test to upload parascriptural'''
+    '''Positive test to upload audiobible'''
     data = [
-    	{'category':'Bible project video','title':"creation", "link":"http://somewhere.com/something"},
-        {'category':'Bible project video', 'title':"abraham's family",
+    	{'name':"creation", "audioFormat":"mp3","link":"http://somewhere.com/something"},
+        {'name':"abraham's family","audioFormat":"mar",
         "link":"http://somewhere.com/something"},
-        {'category':'Bible Stories', 'title':"Isarel's travel routes",
+        {'name':"Isarel's travel routes","audioFormat":"ape",
         "link":"http://somewhere.com/something"},
-        {'category':'Bible Stories', 'title':"the Gods reveals himself in new testament",
+        {'name':"the Gods reveals himself in new testament",
+        "audioFormat":"mp3",
         "reference": {"book":"MAT", "chapter":2, "verseNumber":3, \
             "bookEnd":"JHN", "chapterEnd":5, "verseEnd":6 },
         "link":"http://somewhere.com/something"},
     ]
     response,resource_name = check_post(data)
     assert response.status_code == 201
-    assert response.json()['message'] == "Parascripturals added successfully"
+    assert response.json()['message'] == "Audio Bibles added successfully"
     for item in response.json()['data']:
         assert_positive_get(item)
     assert len(data) == len(response.json()['data'])
     return response,resource_name
 
-def test_post_duplicate():
-    '''Negative test to add two parascripturals Links with same type and title'''
-    data = [
-        {'category':'Bible Stories', 'title':"the Gods reveals himself in new testament",
-        "link":"http://somewhere.com/new"}
-    ]
-    resp, resource_name = check_post(data)
-    assert resp.status_code == 201
-    assert resp.json()['message'] == "Parascripturals added successfully"
-
-    data[0]['link'] = 'http://anotherplace/item'
-    response = client.post(UNIT_URL+resource_name, headers=headers_auth, json=data)
-    assert response.status_code == 409
-    assert response.json()['error'] == "Already Exists"
-
 def test_post_incorrect_data():
     ''' tests to check input validation in post API'''
     # single data object instead of list
-    data = {'category':'Bible Stories', 'title':"the Geneology of Jesus Christ",
+    data = {'name':"the Geneology of Jesus Christ",
+        "audioFormat":"mp3",
         "link":"http://somewhere.com/something"}
     resp, resource_name = check_post(data)
     assert_input_validation_error(resp)
 
-    # data object with missing mandatory fields
-    data = [
-        {'category':'Bible Stories',
-        "link":"http://somewhere.com/something"}
-    ]
-    response = client.post(UNIT_URL+resource_name, headers=headers_auth, json=data)
-    assert_input_validation_error(response)
-
-    data = [
-        {'title':"the Geneology of Jesus Christ",
-        "link":"http://somewhere.com/something"}
-    ]
-    response = client.post(UNIT_URL+resource_name, headers=headers_auth, json=data)
-    assert_input_validation_error(response)
-
     # incorrect data values in fields
     data = [
-        {'category':'mat', 'title':"the Geneology of Jesus Christ",
+        {'name':"the Geneology of Jesus Christ",
+        "audioFormat":"mp3",
         "link":"not a url"}
     ]
     response = client.post(UNIT_URL+resource_name, headers=headers_auth, json=data)
     assert_input_validation_error(response)
 
-
     data = [
-        {'category':'Bible Stories', 'title':"the Geneology of Jesus Christ",
+        {'name':"the Geneology of Jesus Christ",
         "link":"noProtocol.com/something"}
     ]
     response = client.post(UNIT_URL+resource_name, headers=headers_auth, json=data)
     assert_input_validation_error(response)
 
-    resource_name1 = resource_name.replace('parascriptural', 'para')
+    resource_name1 = resource_name.replace('audiobible', 'audio')
     data = []
     response = client.post(UNIT_URL+resource_name1, headers=headers_auth, json=data)
     assert response.status_code == 404
@@ -135,18 +105,11 @@ def test_post_incorrect_data():
     response = client.post(UNIT_URL+resource_name2, headers=headers_auth, json=[])
     assert response.status_code == 404
 
-    # data object with missing mandatory fields
-    data = [
-        {'category':'Bible Stories',
-        "link":"http://somewhere.com/something"}
-    ]
-
     #passing book and bookEnd as integer - negative test
     response = client.post(UNIT_URL+resource_name, headers=headers_auth, json=data)
     data = [
-        {'category':"Bible Stories", 'title':"creation", 'description': "theme for test",
-        'content':"some content for test",
-        "reference": {"book":1, "chapter":2, "verseNumber":3,"bookEnd":20, 
+        {'name':"creation", "audioFormat":"mp3",
+        "reference": {"book":1, "chapter":2, "verseNumber":3,"bookEnd":20,
                     "chapterEnd":5, "verseEnd":6 }
         }
     ]
@@ -156,8 +119,7 @@ def test_post_incorrect_data():
     #passing book and bookEnd not in bookCodePattern expression - negative test
     response = client.post(UNIT_URL+resource_name, headers=headers_auth, json=data)
     data = [
-        {'category':"Bible Stories", 'title':"creation", 'description': "theme for test",
-        'content':"some content for test",
+        {'name':"creation", "audioFormat":"mp3",
         "reference": {"book":"MATHEW", "chapter":2, "verseNumber":3,
                     "bookEnd":"JOHN", "chapterEnd":5, "verseEnd":6 }
         }
@@ -168,8 +130,18 @@ def test_post_incorrect_data():
     #passing non integer value for chapter and verse - negative test
     response = client.post(UNIT_URL+resource_name, headers=headers_auth, json=data)
     data = [
-        {'category':"Bible Stories", 'title':"creation", 'description': "theme for test",
-        'content':"some content for test",
+        {'name':"creation", "audioFormat":"mp3",
+        "reference": {"book":"MAT", "chapter":"firstchapter","verseNumber":"firstverse",
+                    "bookEnd":"JHN", "chapterEnd":"lastchapter", "verseEnd":"lastverse"}
+        }
+    ]
+    response = client.post(UNIT_URL+resource_name, headers=headers_auth, json=data)
+    assert_input_validation_error(response)
+
+    #passing integer value to audio format - negative test
+    response = client.post(UNIT_URL+resource_name, headers=headers_auth, json=data)
+    data = [
+        {'name':"creation", "audioFormat":"mp3",
         "reference": {"book":"MAT", "chapter":"firstchapter","verseNumber":"firstverse",
                     "bookEnd":"JHN", "chapterEnd":"lastchapter", "verseEnd":"lastverse"}
         }
@@ -178,23 +150,23 @@ def test_post_incorrect_data():
     assert_input_validation_error(response)
 
 def test_get_after_data_upload():
-    '''Add some parascripturals data into the table and do all get tests'''  
+    '''Add some audiobibles data into the table and do all get tests'''  
     data = [
-        {'category':"Bible Stories", 'title':"creation", 'description': "theme for test",
-        'content':"some content for test",
+        {'name':"creation", "audioFormat":"mp3",
         "link":"http://somewhere.com/something",
         'reference': {"book":"MAT", "chapter":2, "verseNumber":3,
                     "bookEnd":"JHN", "chapterEnd":5, "verseEnd":6 },
-        'metaData':{'otherName': 'BPV, Bible Project Video'}},
-        {'category':'Bible Stories', 'title':"Noah's Ark",
+        'metaData':{'otherName': 'ABP, Audio Bible Project'}},
+        {'name':"Noah's Ark",
         "link":"http://somewhere.com/something"},
-        {'category':'Bible Stories', 'title':"abraham's family",
+        {'name':"abraham's family",
         "link":"http://somewhere.com/something"},
-        {'category':'Bible project video', 'title':"Isarel's travel routes",
+        {'name':"Isarel's travel routes",
         "link":"http://somewhere.com/something"},
-        {'category':'Bible project video', 'title':"Paul's travel routes",
+        {'name':"Paul's travel routes",
         "link":"http://somewhere.com/something"},
-        {'category':'Bible project video', 'title':"the Gods reveals himself in new testament",
+        {'name':"the Gods reveals himself in new testament",
+        "audioFormat":"mp3",
         'reference': {"book":"MRK", "chapter":2, "verseNumber":10,
                     "bookEnd":"LUK", "chapterEnd":15, "verseEnd":10 },
         "link":"http://somewhere.com/something"}
@@ -203,47 +175,21 @@ def test_get_after_data_upload():
     assert res.status_code == 201
     check_default_get(UNIT_URL+resource_name, headers_auth,assert_positive_get)
 
-    #filter by parascript type
+    # filter with name
     #without auth
-    response = client.get(UNIT_URL+resource_name+'?category=Bible%20Stories')
+    response = client.get(UNIT_URL+resource_name+'?name=creation')
     assert response.status_code == 401
     assert response.json()["error"] == "Authentication Error"
+
     #with auth
-    response = client.get(UNIT_URL+resource_name+'?category=Bible%20Stories',headers=headers_auth)
-    assert response.status_code == 200
-    assert len(response.json()) == 3
-
-    # filter with title
-    response = client.get(UNIT_URL+resource_name+'?title=creation',headers=headers_auth)
+    response = client.get(UNIT_URL+resource_name+'?name=creation',headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 1
 
-    # both title and book
-    response = client.get(UNIT_URL+resource_name+
-        "?category=Bible%20Stories&title=Noah's%20Ark",headers=headers_auth)
+    # filter with audio format
+    response = client.get(UNIT_URL+resource_name+"?audio_format=mp3",headers=headers_auth)
     assert response.status_code == 200
-    assert len(response.json()) == 1
-
-    # filter with description
-    response = client.get(UNIT_URL+resource_name+"?description=theme for test",headers=headers_auth)
-    assert response.status_code == 200
-    assert len(response.json()) == 1
-
-    # filter with description - fuzzy match
-    response = client.get(UNIT_URL+resource_name+"?description=for test",headers=headers_auth)
-    assert response.status_code == 200
-    assert len(response.json()) == 1
-
-    # filter with content - exact match
-    response = client.get(UNIT_URL+resource_name+
-        "?content=some content for test",headers=headers_auth)
-    assert response.status_code == 200
-    assert len(response.json()) == 1
-
-    # filter with content - fuzzy match match
-    response = client.get(UNIT_URL+resource_name+"?content=content for",headers=headers_auth)
-    assert response.status_code == 200
-    assert len(response.json()) == 1
+    assert len(response.json()) == 2
 
     # filter with link
     response = client.get(UNIT_URL+resource_name+"?link=http://somewhere.com/something",
@@ -253,13 +199,13 @@ def test_get_after_data_upload():
 
     # filter with metadata - exact match
     response = client.get(UNIT_URL+resource_name+
-        '?metadata={"otherName": "BPV, Bible Project Video"}',
+        '?metadata={"otherName": "ABP, Audio Bible Project"}',
         headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 1
 
     # filter with metadata - fuzzy match
-    response = client.get(UNIT_URL+resource_name+'?metadata={"otherName": "Project Video"}' ,
+    response = client.get(UNIT_URL+resource_name+'?metadata={"otherName": "Bible Project"}' ,
         headers=headers_auth)
     assert response.status_code == 200
     assert len(response.json()) == 1
@@ -276,6 +222,16 @@ def test_get_after_data_upload():
     # filtering with cross-chapter reference
     response = client.get(UNIT_URL+resource_name+
     '?reference= {"book":"MRK", "chapter":1, \
+                "verseNumber":10,"bookEnd":"MRK", "chapterEnd":10, "verseEnd":15 }',
+        headers=headers_auth)
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+    for item in response.json():
+        assert_positive_get(item)
+
+    # filtering with cross-book reference
+    response = client.get(UNIT_URL+resource_name+
+    '?reference= {"book":"MRK", "chapter":1, \
                 "verseNumber":10,"bookEnd":"LUK", "chapterEnd":10, "verseEnd":1 }',
         headers=headers_auth)
     assert response.status_code == 200
@@ -284,26 +240,23 @@ def test_get_after_data_upload():
         assert_positive_get(item)
 
     # not available resources
-    response = client.get(UNIT_URL+resource_name+'?category=Animations',headers=headers_auth)
+    response = client.get(UNIT_URL+resource_name+'?name=Music',headers=headers_auth)
     assert_not_available_content(response)
 
     response = client.get(UNIT_URL+resource_name+
-        '?category=Bible%20Stories&title=vision',headers=headers_auth)
+        '?name=vision',headers=headers_auth)
     assert_not_available_content(response)
 
 def test_searching():
-    '''Being able to query parascripturals with category,title,
-    content,description,reference and metadata'''
+    '''Being able to query audiobibles with name,audio format,reference and metadata'''
     data = [
         {
-            'category':"Bible Stories",
-            'title':"Creation of World",
-            'description': "theme for test",
-            'content':"some content for test",
+            'name':"Creation of World",
+            "audioFormat":"mp3",
             'reference': {"book":"MAT", "chapter":2, "verseNumber":3,
                 "bookEnd":"JHN", "chapterEnd":5, "verseEnd":6 },
             'link':"http://somewhere.com/something",
-            'metaData': {'otherName': 'BPV, Videos of Bible chapters'}
+            'metaData': {'otherName': 'ABP, Audio Bible Project'}
         }
     ]
 
@@ -311,69 +264,25 @@ def test_searching():
     assert res.status_code == 201
     check_default_get(UNIT_URL+resource_name, headers_auth,assert_positive_get)
 
-    # searching with category - positive test
-    response = client.get(UNIT_URL+resource_name+'?search_word=Stories',headers = headers_auth)
-    assert len(response.json()) > 0
-    found = False
-    for item in response.json():
-        assert_positive_get(item)
-        if item['title'] == "Creation of World":
-            found = True
-    assert found
-
-    # searching with title - positive test
+    # searching with name - positive test
     response = client.get(UNIT_URL+resource_name+'?search_word=of',headers = headers_auth)
+    print("*****res:",response.json())
     assert len(response.json()) > 0
     found = False
     for item in response.json():
         assert_positive_get(item)
-        if item['title'] == "Creation of World":
+        if item['name'] == "Creation of World":
             found = True
     assert found
 
-    # searching with description:exact match - positive test
-    url_with_query_string = UNIT_URL+resource_name+"?search_word=theme for test"
+    # searching with audioformat:- positive test
+    url_with_query_string = UNIT_URL+resource_name+"?audio_format=mp3"
     response = client.get(url_with_query_string, headers=headers_auth)
     assert len(response.json()) > 0
     found = False
     for item in response.json():
         assert_positive_get(item)
-        if item['title'] == "Creation of World":
-            found = True
-    assert found
-
-    # searching with description:fuzzy match - positive test
-    query_string = "for"
-    url_with_query_string = UNIT_URL+resource_name+"?search_word=" + query_string
-    response = client.get(url_with_query_string, headers=headers_auth)
-    assert len(response.json()) > 0
-    found = False
-    for item in response.json():
-        assert_positive_get(item)
-        if item['title'] == "Creation of World":
-            found = True
-    assert found
-
-    # searching with content:exact match - positive test
-    url_with_query_string = UNIT_URL+resource_name+"?search_word=some content for test"
-    response = client.get(url_with_query_string, headers=headers_auth)
-    assert len(response.json()) > 0
-    found = False
-    for item in response.json():
-        assert_positive_get(item)
-        if item['title'] == "Creation of World":
-            found = True
-    assert found
-
-    # searching with content:fuzzy match - positive test
-    query_string = "content for"
-    url_with_query_string = UNIT_URL+resource_name+"?search_word=" + query_string
-    response = client.get(url_with_query_string, headers=headers_auth)
-    assert len(response.json()) > 0
-    found = False
-    for item in response.json():
-        assert_positive_get(item)
-        if item['title'] == "Creation of World":
+        if item['name'] == "Creation of World":
             found = True
     assert found
 
@@ -384,26 +293,27 @@ def test_searching():
     found = False
     for item in response.json():
         assert_positive_get(item)
-        if item['title'] == "Creation of World":
+        if item['name'] == "Creation of World":
             found = True
     assert found
+
     # searching with reference:exact match - positive test
-    response = client.get(UNIT_URL+resource_name+"?search_word=JHN",headers = headers_auth)
+    response = client.get(UNIT_URL+resource_name+"?search_word=MAT",headers = headers_auth)
     assert len(response.json()) > 0
     found = False
     for item in response.json():
         assert_positive_get(item)
-        if item['title'] == "Creation of World":
+        if item['name'] == "Creation of World":
             found = True
     assert found
 
     # searching with reference:partial match - positive test
-    response = client.get(UNIT_URL+resource_name+"?search_word=JHN 2",headers = headers_auth)
+    response = client.get(UNIT_URL+resource_name+"?search_word=MAT 2",headers = headers_auth)
     assert len(response.json()) > 0
     found = False
     for item in response.json():
         assert_positive_get(item)
-        if item['title'] == "Creation of World":
+        if item['name'] == "Creation of World":
             found = True
     assert found
 
@@ -414,23 +324,24 @@ def test_searching():
     assert_not_available_content(response)
 
     # searching with metadata with special characters:exact match - positive test
-    response = client.get(UNIT_URL+resource_name+"?search_word=BPV, Videos of Bible chapters",
+    response = client.get(UNIT_URL+resource_name+"?search_word=ABP, Audio Bible Project",
         headers = headers_auth)
     assert len(response.json()) > 0
     found = False
     for item in response.json():
         assert_positive_get(item)
-        if item['title'] == "Creation of World":
+        if item['name'] == "Creation of World":
             found = True
     assert found
 
     # searching with partial metadata:fuzzy match - positive test
-    response = client.get(UNIT_URL+resource_name+"?search_word=of chapters",headers = headers_auth)
+    response = client.get(UNIT_URL+resource_name+"?search_word=Bible Project",headers = headers_auth)
+    print("?????resp:",response.json())
     assert len(response.json()) > 0
     found = False
     for item in response.json():
         assert_positive_get(item)
-        if item['title'] == "Creation of World":
+        if item['name'] == "Creation of World":
             found = True
     assert found
 
@@ -439,7 +350,7 @@ def test_searching():
     assert len(response.json()) ==  0
     found = False
     for item in response.json():
-        if item['title'] == "Creation of World":
+        if item['name'] == "Creation of World":
             found = True
     assert not found
 
@@ -450,18 +361,110 @@ def test_get_incorrect_data():
     assert_input_validation_error(response)
     resp, resource_name = check_post([])
     assert resp.status_code == 201
-    resource_name = resource_name.replace('parascriptural', 'graphics')
+    resource_name = resource_name.replace('audiobible', 'audio')
     response = client.get(UNIT_URL+resource_name, headers=headers_auth)
     assert response.status_code == 404
+
+def test_references():
+    '''Tests for handling verses in reference'''
+    data = [
+        {'name':"12 apostles",
+        "reference": {"book":"MAT", "chapter":2, "verseNumber":3, \
+            "bookEnd":"JHN", "chapterEnd":5, "verseEnd":6 },
+        "link":"http://somewhere.com/something"},
+        {'name':"miracles",
+        "reference": {"book":"MRK", "chapter":2, \
+            "bookEnd":"LUK", "chapterEnd":5, "verseEnd":6 },
+        "link":"http://somewhere.com/something"},
+        {'name':"origin of world",
+        "reference": {"book":"GEN", "chapter":1, "verseNumber":1, \
+            "bookEnd":"GEN", "chapterEnd":2},
+        "link":"http://somewhere.com/something"}
+    ]
+    response, resource_name = check_post(data)
+    assert response.status_code == 201
+
+    get_response = client.get(UNIT_URL+resource_name,headers=headers_auth)
+
+    # Case 1 : passing both starting and ending verses - positive test
+    assert get_response.json()[0]['name'] == "12 apostles"
+    assert get_response.json()[0]['reference']['verseNumber'] == 3
+    assert get_response.json()[0]['reference']['verseEnd'] == 6
+
+    # Case 2: passing only ending and  verse- positive test
+    assert get_response.json()[1]['name'] == "miracles"
+    assert get_response.json()[1]['reference']['verseNumber'] == 0
+    assert get_response.json()[1]['reference']['verseEnd'] == 6
+
+    # Case 3 : passing only starting verse- positive test
+    assert get_response.json()[2]['name'] == "origin of world"
+    assert get_response.json()[2]['reference']['verseNumber'] == 1
+    assert get_response.json()[2]['reference']['verseEnd'] == 999
+   
+    # case 4: verse start > verse end - negative test
+    data = [
+        {'name':"resurrection",
+        "reference": {"book":"MAT", "chapter":2, "verseNumber":30, \
+            "bookEnd":"JHN", "chapterEnd":10, "verseEnd":6 },
+        "link":"http://somewhere.com/something"}
+    ]
+    response = client.post('/v2/resources', headers=headers_auth, json=data)
+    assert response.status_code == 422
+    assert_input_validation_error(response)
+
+    # Handling chapters
+    # case 1 : assigning invalid values to chapter - negative test
+    data = [
+        {'name':"resurrection",
+        "reference": {"book":"MAT", "chapter":0, "verseNumber":3, \
+            "bookEnd":"JHN", "chapterEnd":5, "verseEnd":6 },
+        "link":"http://somewhere.com/something"}
+    ]
+    response = client.post('/v2/resources', headers=headers_auth, json=data)
+    assert response.status_code == 422
+    assert_input_validation_error(response)
+
+    # case 2 - chapter = -1 - negative test
+    data = [
+        {'name':"resurrection",
+        "reference": {"book":"MAT", "chapter":-1 ,"verseNumber":3, \
+            "bookEnd":"JHN", "chapterEnd":5, "verseEnd":6 },
+        "link":"http://somewhere.com/something"}
+    ]
+    response = client.post('/v2/resources', headers=headers_auth, json=data)
+    assert response.status_code == 422
+    assert_input_validation_error(response)
+
+    # case 3: chapter start > chapter end - negative test
+    data = [
+        {'name':"resurrection",
+        "reference": {"book":"MAT", "chapter":20, "verseNumber":3, \
+            "bookEnd":"JHN", "chapterEnd":2, "verseEnd":6 },
+        "link":"http://somewhere.com/something"}
+    ]
+    response = client.post('/v2/resources', headers=headers_auth, json=data)
+    assert response.status_code == 422
+    assert_input_validation_error(response)
+
+     # case 4: not passing chapter field - negative test
+    data = [
+        {'name':"resurrection",
+        "reference": {"book":"MAT", "verseNumber":3, \
+            "bookEnd":"JHN", "verseEnd":6 },
+        "link":"http://somewhere.com/something"}
+    ]
+    response = client.post('/v2/resources', headers=headers_auth, json=data)
+    assert response.status_code == 422
+    assert_input_validation_error(response)
 
 def test_put_after_upload():
     '''Positive tests for put'''
     data = [
-        {'category':'Bible Stories', 'title':"12 apostles",
+        {'name':"12 apostles",
         "reference": {"book":"MAT", "chapter":2, "verseNumber":3, \
             "bookEnd":"JHN", "chapterEnd":5, "verseEnd":6 },
         "link":"http://somewhere.com/something"},
-        {'category':'Bible Project Video', 'title':"miracles",
+        {'name':"miracles",
         "reference": {"book":"MRK", "chapter":2, "verseNumber":3, \
             "bookEnd":"LUK", "chapterEnd":5, "verseEnd":6 },
         "link":"http://somewhere.com/something"}
@@ -469,34 +472,37 @@ def test_put_after_upload():
     response, resource_name = check_post(data)
     assert response.status_code == 201
 
+    get_response = client.get(UNIT_URL+resource_name,headers=headers_auth)
+    audio_id_1 = get_response.json()[0]['audioId']
+    audio_id_2 = get_response.json()[1]['audioId']
+
     # positive PUT
     new_data = [
-        {'category':'Bible Stories', 'title':"12 apostles",
+        {'audioId':audio_id_1,
+        'name':"12 apostles",
         "reference": {"book":"MRK", "chapter":10, "verseNumber":11, \
             "bookEnd":"LUK", "chapterEnd":12, "verseEnd":13 },
         "link":"http://anotherplace.com/something",
         "metaData":{"newkey1":"newvalue1"}},
-        {'category':'Bible Project Video', 'title':"miracles",
+        {'audioId':audio_id_2,
+        'name':"miracles",
         "reference": {"book":"MAT", "chapter":10, "verseNumber":11, \
             "bookEnd":"JHN", "chapterEnd":12, "verseEnd":13 },
         "link":"http://somewhereelse.com/something",
         "metaData":{"newkey2":"newvalue2"}}
     ]
     #without auth
-    response = client.put(UNIT_URL+resource_name,headers=headers, json=new_data)
+    response = client.put(UNIT_URL+resource_name, json=new_data)
     assert response.status_code == 401
     assert response.json()['error'] == 'Authentication Error'
     #with auth
     response = client.put(UNIT_URL+resource_name,headers=headers_auth, json=new_data)
     assert response.status_code == 201
-    print("***********:",response.json())
-    assert response.json()['message'] == 'Parascripturals updated successfully'
+    
+    assert response.json()['message'] == 'Audio Bibles updated successfully'
     for i,item in enumerate(response.json()['data']):
         assert_positive_get(item)
-        print("item:",item)
-        # assert response.json()['data'][i]['bible'] is None
-        assert response.json()['data'][i]['category'] == new_data[i]['category']
-        assert response.json()['data'][i]['title'] == new_data[i]['title']
+        assert response.json()['data'][i]['name'] == new_data[i]['name']
         assert response.json()['data'][i]['reference']['book'] == new_data[i]['reference']['book']
         assert response.json()['data'][i]['reference']['chapter'] == new_data[i]['reference']['chapter']
         assert response.json()['data'][i]['reference']['verseNumber'] == new_data[i]['reference']['verseNumber']
@@ -504,11 +510,6 @@ def test_put_after_upload():
         assert response.json()['data'][i]['reference']['chapterEnd'] == new_data[i]['reference']['chapterEnd']
         assert response.json()['data'][i]['reference']['verseEnd'] == new_data[i]['reference']['verseEnd']
         assert response.json()['data'][i]['metaData'] == new_data[i]['metaData']
-
-    # not available PUT
-    new_data[0]['category'] = 'Bible Stories New'
-    response = client.put(UNIT_URL+resource_name, headers=headers_auth, json=new_data)
-    assert response.status_code == 404
 
     resource_name = resource_name.replace('1', '10')
     response = client.put(UNIT_URL+resource_name, headers=headers_auth, json=[])
@@ -518,38 +519,42 @@ def test_put_incorrect_data():
     ''' tests to check input validation in put API'''
 
     post_data = [
-        {'category':'Bible Stories', 'title':"miracles",
+        {'name':"miracles",
         "link":"http://somewhere.com/something"},
-        {'category':'Bible project video', 'title':"12 apostles",
+        {'name':"12 apostles",
         "link":"http://somewhere.com/something"}
     ]
     resp, resource_name = check_post(post_data)
     assert resp.status_code == 201
 
+    get_response = client.get(UNIT_URL+resource_name,headers=headers_auth)
+    audio_id_1 = get_response.json()[0]['audioId']
+    audio_id_2 = get_response.json()[1]['audioId']
     # single data object instead of list
-    data =  {'category':'Bible Stories', 'title':"12 apostles",
-        "link":"http://anotherplace.com/something"}
+    data =  {'audioId': audio_id_1,
+            'name':"apostles",
+            "link":"http://anotherplace.com/something"}
     response = client.put(UNIT_URL+resource_name, headers=headers_auth, json=data)
     assert_input_validation_error(response)
 
     # data object with missing mandatory fields
     data = [
-        {'title':"12 apostles",
+        {'name':"12 apostles",
         "link":"http://anotherplace.com/something"}
             ]
     response = client.put(UNIT_URL+resource_name, headers=headers_auth, json=data)
     assert_input_validation_error(response)
 
     data = [
-        {'category':'Bible Stories',
-        "link":"http://somewhere.com/something"}    ]
+        {"link":"http://somewhere.com/something"}    ]
     response = client.put(UNIT_URL+resource_name, headers=headers_auth, json=data)
     assert_input_validation_error(response)
 
     # incorrect data values in fields
     #updating with reference in incorrect syntax of bookCode
     data = [
-        {'category':'Bible Stories', 'title':"12 apostles",
+        {'audioId': audio_id_2,
+        'name':"12 apostles",
         "reference": {"book":"MATHEW", "chapter":2, "verseNumber":3,
                     "bookEnd":"JOHN", "chapterEnd":5, "verseEnd":6 }
         }
@@ -559,13 +564,14 @@ def test_put_incorrect_data():
 
     #updating with link in incorrect syntax
     data = [
-        {'category':'Bible Stories', 'title':"12 apostles",
+        {'audioId': audio_id_2,
+        'name':"12 apostles",
         "link":"filename.txt"}    ]
     response = client.put(UNIT_URL+resource_name, headers=headers_auth, json=data)
     assert_input_validation_error(response)
 
     #updating with incorrect resource name
-    resource_name1 = resource_name.replace('parascriptural', 'graphics')
+    resource_name1 = resource_name.replace('audiobible', 'audio')
     response = client.put(UNIT_URL+resource_name1, headers=headers_auth, json=[])
     assert response.status_code == 404
 
@@ -591,7 +597,7 @@ def test_created_user_can_only_edit():
     }
     add_version(version_data)
     data = {
-        "contentType": "parascriptural",
+        "contentType": "audiobible",
         'language': 'ml',
         "version": "TTT",
         "year": 2020
@@ -602,25 +608,31 @@ def test_created_user_can_only_edit():
     assert response.json()['message'] == "Resource created successfully"
     resource_name = response.json()['data']['resourceName']
 
-    #create parascripturals
+    #create audiobibles
     data = [
-        {'category':'Bible Stories', 'title':"12 apostles",
+        {'name':"12 apostles",
         "link":"http://somewhere.com/something"},
-        {'category':'Bible project video', 'title':"miracles",
+        {'name':"miracles",
         "link":"http://somewhere.com/something"}
     ]
     response = client.post(UNIT_URL+resource_name, headers=headers_auth, json=data)
     assert response.status_code == 201
 
-    #update parascripturals with created SA user
+    get_response = client.get(UNIT_URL+resource_name,headers=headers_auth)
+    audio_id_1 = get_response.json()[0]['audioId']
+    audio_id_2 = get_response.json()[1]['audioId']
+
+    #update audiobibles with created SA user
     new_data = [
-        {'category':'Bible Stories', 'title':"12 apostles",
+        {'audioId': audio_id_1,
+        'name':"12 apostles",
         "link":"http://anotherplace.com/something"},
-        {'category':'Bible project video', 'title':"miracles",
+        {'audioId': audio_id_1,
+        'name':"miracles",
         "link":"http://somewhereelse.com/something"}]
     response = client.put(UNIT_URL+resource_name,headers=headers_auth, json=new_data)
     assert response.status_code == 201
-    assert response.json()['message'] == 'Parascripturals updated successfully'
+    assert response.json()['message'] == 'Audio Bibles updated successfully'
 
     #update with VA not created user
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['VachanAdmin']['token']
@@ -631,38 +643,38 @@ def test_created_user_can_only_edit():
 def test_get_access_with_user_roles_and_apps():
     """Test get filter from apps and with users having different permissions"""
     data = [
-    	{'category':'Bible Stories', 'title':"12 apostles",
+    	{'name':"12 apostles",
         "link":"http://somewhere.com/something"}
     ]
-    contetapi_get_accessrule_checks_app_userroles("parascriptural",UNIT_URL,data)
+    contetapi_get_accessrule_checks_app_userroles("audiobible",UNIT_URL,data)
 
 def test_soft_delete():
-    '''check soft delete in parascripturals'''
+    '''check soft delete in audiobibles'''
     data = [
-        {'category':'Bible Stories', 'title':"the Gods reveals himself in new testament",
+        {'name':"the Gods reveals himself in new testament",
         "reference": {"book":"MAT", "chapter":2, "verseNumber":3,\
             "bookEnd":"JHN", "chapterEnd":5, "verseEnd":6 },
         "link":"http://somewhere.com/something"
         }
             ]
-
-    delete_data = [
-        {'category':'Bible Stories', 'title':'the Gods reveals himself in new testament'}
-    ]
-
     response, resource_name = check_post(data)
     assert response.json()
 
     get_response1 = client.get(UNIT_URL+resource_name,headers=headers_auth)
+    audio_id = get_response1.json()[0]['audioId']
+    delete_data = [
+        {
+            'audioId':audio_id,
+            'name' :"the Gods reveals himself in new testament"
+        }
+    ]
     assert len(get_response1.json()) == len(data)
     delete_data[0]['active'] = False
 
     response = client.put(UNIT_URL+resource_name,headers=headers_auth, json=delete_data)
     assert response.status_code == 201
     assert response.json()
-    assert response.json()["message"] == "Parascripturals updated successfully"
-    # for i,item in enumerate(response.json()['data']['output']['data']): #pylint: disable=unused-variable
-    #     assert not item['active']
+    assert response.json()["message"] == "Audio Bibles updated successfully"
 
     get_response2 = client.get(UNIT_URL+resource_name, headers=headers_auth)
     assert len(get_response2.json()) == len(data) - len(delete_data)
@@ -671,55 +683,55 @@ def test_soft_delete():
     assert len(get_response3.json()) == len(delete_data)
 
 def test_delete_default():
-    ''' positive test case, checking for correct return of deleted parascriptural ID'''
+    ''' positive test case, checking for correct return of deleted audiobible ID'''
     #create new data
     response,resource_name = test_post_default()
     headers_auth = {"contentType": "application/json",#pylint: disable=redefined-outer-name
                 "accept": "application/json"}
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['VachanAdmin']['token']
     post_response = client.get(UNIT_URL+resource_name+ \
-        "?book_code=Bible%20project%20video&title=creation",\
+        "?book_code=Bible%20project%20audio&name=creation",\
         headers=headers_auth)
     assert post_response.status_code == 200
     assert len(post_response.json()) == 1
     for item in post_response.json():
         assert_positive_get(item)
-    parascript_response = client.get(UNIT_URL+resource_name,headers=headers_auth)
-    parascript_id = parascript_response.json()[0]['parascriptId']
+    audio_response = client.get(UNIT_URL+resource_name,headers=headers_auth)
+    audio_id = audio_response.json()[0]['audioId']
 
     #Delete without authentication
     headers = {"contentType": "application/json", "accept": "application/json"}#pylint: disable=redefined-outer-name
     response = client.delete(UNIT_URL+resource_name + \
-        "?delete_id=" + str(parascript_id), headers=headers)
+        "?delete_id=" + str(audio_id), headers=headers)
     assert response.status_code == 401
     assert response.json()['error'] == 'Authentication Error'
 
-     #Delete parascriptural with other API user,AgAdmin,AgUser,VachanUser,BcsDev,'VachanContentAdmin','VachanContentViewer'
+     #Delete audiobible with other API user,AgAdmin,AgUser,VachanUser,BcsDev,'VachanContentAdmin','VachanContentViewer'
     for user in ['APIUser','AgAdmin','AgUser','VachanUser','BcsDev','VachanContentAdmin','VachanContentViewer']:
         headers_au = {"contentType": "application/json",
                     "accept": "application/json",
                     'Authorization': "Bearer"+" "+initial_test_users[user]['token']
         }
         response = client.delete(UNIT_URL+resource_name + \
-            "?delete_id=" + str(parascript_id), headers=headers_au)
+            "?delete_id=" + str(audio_id), headers=headers_au)
         assert response.status_code == 403
         assert response.json()['error'] == 'Permission Denied'
 
-    #Delete parascriptural with Vachan Admin
+    #Delete audiobible with Vachan Admin
     headers_va = {"contentType": "application/json",
                     "accept": "application/json",
                     'Authorization': "Bearer"+" "+initial_test_users['VachanAdmin']['token']
             }
     response = client.delete(UNIT_URL+resource_name + \
-        "?delete_id=" + str(parascript_id), headers=headers_va)
+        "?delete_id=" + str(audio_id), headers=headers_va)
     assert response.status_code == 200
     assert response.json()['message'] ==\
-         f"Parascriptural id {parascript_id} deleted successfully"
+         f"Audio Bible id {audio_id} deleted successfully"
 
 
 def test_delete_default_superadmin():
-    ''' positive test case, checking for correct return of deleted parascriptural ID'''
-    #Created User or Super Admin can only delete parascriptural
+    ''' positive test case, checking for correct return of deleted audiobible ID'''
+    #Created User or Super Admin can only delete audiobible
     #creating data
     response,resource_name = test_post_default()
 
@@ -736,26 +748,26 @@ def test_delete_default_superadmin():
                     'Authorization': "Bearer"+" "+test_user_token
             }
 
-    parascript_response = client.get(UNIT_URL+resource_name,headers=headers_sa)
-    parascript_id = parascript_response.json()[0]['parascriptId']
+    audio_response = client.get(UNIT_URL+resource_name,headers=headers_sa)
+    audio_id = audio_response.json()[0]['audioId']
 
-     #Delete parascriptural with Super Admin
+     #Delete audiobible with Super Admin
     response = client.delete(UNIT_URL+resource_name + "?delete_id=" +\
-         str(parascript_id), headers=headers_sa)
+         str(audio_id), headers=headers_sa)
     assert response.status_code == 200
     assert response.json()['message'] ==\
-         f"Parascriptural id {parascript_id} deleted successfully"
-    #Check parascriptural is deleted from table
-    parascript_response = client.get(UNIT_URL+resource_name,headers=headers_sa)
+         f"Audio Bible id {audio_id} deleted successfully"
+    #Check audiobible is deleted from table
+    audio_response = client.get(UNIT_URL+resource_name,headers=headers_sa)
     post_response = client.get(UNIT_URL+resource_name+ \
-        "?book_code=Bible%20project%20video&title=creation",\
+        "?book_code=Bible%20project%20audio&name=creation",\
         headers=headers_sa)
     assert_not_available_content(post_response)
     logout_user(test_user_token)
     return response,resource_name
 
-def test_delete_parascript_id_string():
-    '''positive test case, parascriptural id as string'''
+def test_delete_audio_id_string():
+    '''positive test case, audiobible id as string'''
     response,resource_name = test_post_default()
 
     #Login as Super Admin
@@ -771,23 +783,23 @@ def test_delete_parascript_id_string():
                     'Authorization': "Bearer"+" "+test_user_token
             }
 
-    parascript_response = client.get(UNIT_URL+resource_name,headers=headers_sa)
-    parascript_id = parascript_response.json()[0]['parascriptId']
-    parascript_id = str(parascript_id)
+    audio_response = client.get(UNIT_URL+resource_name,headers=headers_sa)
+    audio_id = audio_response.json()[0]['audioId']
+    audio_id = str(audio_id)
 
-    #Delete parascriptural with Super Admin
+    #Delete audiobible with Super Admin
     response = client.delete(UNIT_URL+resource_name + \
-        "?delete_id=" + str(parascript_id), headers=headers_sa)
+        "?delete_id=" + str(audio_id), headers=headers_sa)
     assert response.status_code == 200
     assert response.json()['message'] ==\
-         f"Parascriptural id {parascript_id} deleted successfully"
-    #Check parascriptural parascriptural is deleted from table
-    parascript_response = client.get(UNIT_URL+resource_name,headers=headers_sa)
+         f"Audio Bible id {audio_id} deleted successfully"
+    #Check audiobible audiobible is deleted from table
+    audio_response = client.get(UNIT_URL+resource_name,headers=headers_sa)
     logout_user(test_user_token)
 
 
-def test_delete_missingvalue_parascript_id():
-    '''Negative Testcase. Passing input data without parascriptId'''
+def test_delete_missingvalue_audio_id():
+    '''Negative Testcase. Passing input data without audioId'''
     response,resource_name = test_post_default()
 
     #Login as Super Admin
@@ -822,15 +834,15 @@ def test_delete_missingvalue_resource_name():
                     "accept": "application/json",
                     'Authorization': "Bearer"+" "+test_user_token
             }
-    parascript_response = client.get(UNIT_URL+resource_name,headers=headers_sa)
-    parascript_id = parascript_response.json()[0]['parascriptId']
+    audio_response = client.get(UNIT_URL+resource_name,headers=headers_sa)
+    audio_id = audio_response.json()[0]['audioId']
 
-    response = client.delete(UNIT_URL+ "?delete_id=" + str(parascript_id), headers=headers_sa)
+    response = client.delete(UNIT_URL+ "?delete_id=" + str(audio_id), headers=headers_sa)
     assert response.status_code == 404
     logout_user(test_user_token)
 
 def test_delete_notavailable_content():
-    ''' request a non existing parascriptural ID, Ensure there is no partial matching'''
+    ''' request a non existing audiobible ID, Ensure there is no partial matching'''
     response,resource_name = test_post_default()
 
     #Login as Super Admin
@@ -845,10 +857,10 @@ def test_delete_notavailable_content():
                     "accept": "application/json",
                     'Authorization': "Bearer"+" "+test_user_token
             }
-    parascript_id=20000
-     #Delete parascriptural with Super Admin
+    audio_id=20000
+     #Delete audiobible with Super Admin
     response = client.delete(UNIT_URL+resource_name + \
-        "?delete_id=" + str(parascript_id), headers=headers_sa)
+        "?delete_id=" + str(audio_id), headers=headers_sa)
     assert response.status_code == 404
     assert response.json()['error'] == "Requested Content Not Available"
     logout_user(test_user_token)
@@ -895,9 +907,9 @@ def test_restore_default():
     assert response.status_code == 201
     assert response.json()['message'] == \
     f"Deleted Item with identity {deleteditem_id} restored successfully"
-    #Check parascriptural exists after restore
+    #Check audiobible exists after restore
     restore_response =  client.get(UNIT_URL+resource_name+ \
-        "?category=Bible project video&title=creation",\
+        "?name=creation",\
         headers=headers_auth)
     assert restore_response.status_code == 200
     assert len(restore_response.json()) == 1

--- a/app/test/test_sign_bible_videos.py
+++ b/app/test/test_sign_bible_videos.py
@@ -299,7 +299,7 @@ def test_searching():
     assert found
 
     # searching with reference:partial match - positive test
-    response = client.get(UNIT_URL+resource_name+"?search_word=MA",headers = headers_auth)
+    response = client.get(UNIT_URL+resource_name+"?search_word=MAT 2",headers = headers_auth)
     assert len(response.json()) > 0
     found = False
     for item in response.json():

--- a/db/seed_DB.sql
+++ b/db/seed_DB.sql
@@ -13,6 +13,7 @@ INSERT INTO content_types(content_type) VALUES('bible');
 INSERT INTO content_types(content_type) VALUES('commentary');
 INSERT INTO content_types(content_type) VALUES('vocabulary');
 INSERT INTO content_types(content_type) VALUES('parascriptural');
+INSERT INTO content_types(content_type) VALUES('audiobible'); 
 INSERT INTO content_types(content_type) VALUES('signbiblevideo'); 
 INSERT INTO content_types(content_type) VALUES('gitlabrepo'); 
 


### PR DESCRIPTION
- #624 
- Has **database changes**
- Removed link between text bibles and audio bibles from codebase. Now while creating a `resource` of type `bible` only `table` and `table_cleaned` dynamic tables are created.
- Introduced new resource type `audiobible`
- Included GET,POST,PUT,DELETE API calls of audio bible
- Included testcases for audio bible