### PR TITLE
Distinguish translation projects based on Apps

### DIFF
--- a/app/auth/authentication.py
+++ b/app/auth/authentication.py
@@ -231,7 +231,7 @@ def check_right(user_details, required_rights, resp_obj=None, db_=None):
     return False
 
 
-def get_auth_access_check_decorator(func):#pylint:disable=too-many-statements
+def get_auth_access_check_decorator(func):#pylint:disable=too-many-statements,duplicate-code
     """Decorator function for auth and access check for all routers"""
     @wraps(func)
     async def wrapper(*args, **kwargs):#pylint: disable=too-many-branches,too-many-statements, too-many-locals

--- a/app/auth/authentication.py
+++ b/app/auth/authentication.py
@@ -231,7 +231,7 @@ def check_right(user_details, required_rights, resp_obj=None, db_=None):
     return False
 
 
-def get_auth_access_check_decorator(func):#pylint:disable=too-many-statements,duplicate-code
+def get_auth_access_check_decorator(func):#pylint:disable=too-many-statements
     """Decorator function for auth and access check for all routers"""
     @wraps(func)
     async def wrapper(*args, **kwargs):#pylint: disable=too-many-branches,too-many-statements, too-many-locals

--- a/app/crud/projects_crud.py
+++ b/app/crud/projects_crud.py
@@ -195,8 +195,8 @@ def update_translation_project(db_:Session, project_obj, user_id=None):
     # db_.commit()
     # db_.refresh(project_row)
     return project_row
-
-def check_app_compatibility_decorator(func):#pylint:disable=too-many-statements,duplicate-code
+# pylint: disable=duplicate-code
+def check_app_compatibility_decorator(func):#pylint:disable=too-many-statements
     """Decorator function for to check app compatibility"""
     @wraps(func)
     async def wrapper(*args, **kwargs):#pylint: disable=too-many-branches,too-many-statements
@@ -263,6 +263,7 @@ def check_app_compatibility_decorator(func):#pylint:disable=too-many-statements,
             raise HTTPException(status_code=403, detail="Incompatible app")
         return await func(*args, **kwargs)
     return wrapper
+# pylint: enable=duplicate-code
 
 def get_translation_projects(db_:Session, project_name=None, source_language=None,
     target_language=None, **kwargs):

--- a/app/crud/projects_crud.py
+++ b/app/crud/projects_crud.py
@@ -215,7 +215,7 @@ def check_app_compatibility_decorator(func):#pylint:disable=too-many-statements
                 project_id = parsed_data['projectId']
             elif 'project_id' in parsed_data:
                 project_id = parsed_data['project_id']
-            elif 'project_id' in query_params:
+            if 'project_id' in query_params:
                 project_id = query_params['project_id']
         else:
             project_id = query_params['project_id']
@@ -226,8 +226,6 @@ def check_app_compatibility_decorator(func):#pylint:disable=too-many-statements
         else:
             if 'compatibleWith' in parsed_data and parsed_data['compatibleWith'] is not None:
                 compatible_with = parsed_data['compatibleWith']
-            else:
-                compatible_with = request.headers['app']
         if 'app' in request.headers:
             client_app = request.headers['app']
             if len(compatible_with) ==0:

--- a/app/crud/projects_crud.py
+++ b/app/crud/projects_crud.py
@@ -196,7 +196,7 @@ def update_translation_project(db_:Session, project_obj, user_id=None):
     # db_.refresh(project_row)
     return project_row
 
-def check_app_compatibility_decorator(func):#pylint:disable=too-many-statements
+def check_app_compatibility_decorator(func):#pylint:disable=too-many-statements,duplicate-code
     """Decorator function for to check app compatibility"""
     @wraps(func)
     async def wrapper(*args, **kwargs):#pylint: disable=too-many-branches,too-many-statements

--- a/app/db_models.py
+++ b/app/db_models.py
@@ -358,6 +358,7 @@ class TranslationProject(Base): # pylint: disable=too-few-public-methods
     updatedUser = Column('last_updated_user', String)
     createTime = Column('created_at', DateTime, default=ist_time)
     updateTime = Column('last_updated_at', DateTime, onupdate= ist_time,default=ist_time)
+    compatibleWith = Column('compatible_with', String)
 
 class TranslationDraft(Base): # pylint: disable=too-few-public-methods
     '''Corresponds to table translation_drafts in vachan DB used by Autographa MT mode'''

--- a/app/db_models.py
+++ b/app/db_models.py
@@ -358,7 +358,7 @@ class TranslationProject(Base): # pylint: disable=too-few-public-methods
     updatedUser = Column('last_updated_user', String)
     createTime = Column('created_at', DateTime, default=ist_time)
     updateTime = Column('last_updated_at', DateTime, onupdate= ist_time,default=ist_time)
-    compatibleWith = Column('compatible_with', String)
+    compatibleWith = Column('compatible_with', ARRAY(String))
 
 class TranslationDraft(Base): # pylint: disable=too-few-public-methods
     '''Corresponds to table translation_drafts in vachan DB used by Autographa MT mode'''

--- a/app/routers/translation_apis.py
+++ b/app/routers/translation_apis.py
@@ -47,7 +47,6 @@ async def get_projects(request: Request,
     422: {"model": schemas.ErrorResponse},401: {"model": schemas.ErrorResponse}},
     tags=['Translation-Project management'])
 @get_auth_access_check_decorator
-@check_app_compatibility_decorator
 async def create_project(request: Request,
     project_obj:schemas_nlp.TranslationProjectCreate,
     user_details =Depends(get_user_or_none), db_:Session=Depends(get_db)):

--- a/app/schema/schemas_nlp.py
+++ b/app/schema/schemas_nlp.py
@@ -54,7 +54,7 @@ class TranslationProjectCreate(BaseModel):
         example=[',', '"', '!', '.', ':', ';', '\n', '\\','“','”',
         '“','*','।','?',';',"'","’","(",")","‘","—"])
     active: bool = True
-    compatibleWith: App = Field(None,example='SanketMAST')
+    compatibleWith: List[App] = Field(None,example=['SanketMAST'])
 
 class TranslationProject(BaseModel):
     '''Output object for project creation'''
@@ -69,7 +69,7 @@ class TranslationProject(BaseModel):
     metaData: dict = Field(None, example={"books":['mat', 'mrk', 'luk', 'jhn'],
         "useDataForLearning":True})
     active: bool
-    compatibleWith: App = Field(None,example='SanketMAST')
+    compatibleWith: List[App] = Field(None,example=['SanketMAST'])
     class Config:
         ''' telling Pydantic exactly that "it's OK if I pass a non-dict value,
         just get the data from object attributes'''
@@ -105,7 +105,7 @@ class TranslationProjectEdit(BaseModel):
     useDataForLearning: bool = None
     stopwords: Stopwords = None
     punctuations: List[constr(max_length=1)] = None
-    compatibleWith: App = Field(None,example='SanketMAST')
+    compatibleWith: List[App] = Field(None,example=['SanketMAST'])
 
 class TranslationProjectUpdateResponse(BaseModel):
     '''Response for post and put'''

--- a/app/schema/schemas_nlp.py
+++ b/app/schema/schemas_nlp.py
@@ -26,7 +26,7 @@ class Stopwords(BaseModel):
 
 class ProjectUser(BaseModel):
     '''Input object for Translation project user update'''
-    project_id: int
+    project_id: int = None
     userId: str
     userRole: str = Field(None, example='projectOwner')
     metaData: dict = Field(None, example={
@@ -96,7 +96,6 @@ class SentenceInput(BaseModel):
 
 class TranslationProjectEdit(BaseModel):
     '''New books to be added or active flag change'''
-    projectId: int
     projectName: str = None
     active: bool = None
     selectedBooks: SelectedBooks = None

--- a/app/schema/schemas_nlp.py
+++ b/app/schema/schemas_nlp.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field, constr, root_validator
 
 from schema.schemas import LangCodePattern, TableNamePattern, LanguageResponse
 from schema.schema_content import BookCodePattern, Job
+from schema.schema_auth import App
 
 #pylint: disable=too-few-public-methods
 class TranslationDocumentType(Enum):
@@ -53,6 +54,7 @@ class TranslationProjectCreate(BaseModel):
         example=[',', '"', '!', '.', ':', ';', '\n', '\\','“','”',
         '“','*','।','?',';',"'","’","(",")","‘","—"])
     active: bool = True
+    compatibleWith: App = Field(None,example='SanketMAST')
 
 class TranslationProject(BaseModel):
     '''Output object for project creation'''
@@ -67,6 +69,7 @@ class TranslationProject(BaseModel):
     metaData: dict = Field(None, example={"books":['mat', 'mrk', 'luk', 'jhn'],
         "useDataForLearning":True})
     active: bool
+    compatibleWith: App = Field(None,example='SanketMAST')
     class Config:
         ''' telling Pydantic exactly that "it's OK if I pass a non-dict value,
         just get the data from object attributes'''
@@ -102,6 +105,7 @@ class TranslationProjectEdit(BaseModel):
     useDataForLearning: bool = None
     stopwords: Stopwords = None
     punctuations: List[constr(max_length=1)] = None
+    compatibleWith: App = Field(None,example='SanketMAST')
 
 class TranslationProjectUpdateResponse(BaseModel):
     '''Response for post and put'''

--- a/app/test/test_agmt_projects.py
+++ b/app/test/test_agmt_projects.py
@@ -1375,19 +1375,7 @@ def test_post_put_app_compatibility():
     assert len(new_project['metaData']['books']) == 0
     assert new_project['active']
 
-    # Create new project with incompatible app - Negative Test
-    post_data_2= {
-    "projectName": "Test project 3",
-    "sourceLanguageCode": "hi",
-    "targetLanguageCode": "ml",
-    "compatibleWith": ["SanketMAST"]
-    }
-    response = client.post(UNIT_URL, headers=headers_auth, json=post_data_2)
-    assert response.status_code == 403
-    assert response.json()['details'] == "Incompatible app"
-
     # update data with compatible app not passed as a list - negative test
-
     put_data = {
     "uploadedUSFMs":[bible_books['mat']]
     }

--- a/app/test/test_agmt_projects.py
+++ b/app/test/test_agmt_projects.py
@@ -91,10 +91,10 @@ def test_default_post_put_get():
 
     # upload books
     put_data = {
-    "projectId":new_project['projectId'],
     "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    response2 = client.put(UNIT_URL+'?project_id='+str(new_project['projectId']),\
+         headers=headers_auth, json=put_data)
     assert response2.status_code == 201
     assert response2.json()['message'] == "Project updated successfully"
     updated_project = response2.json()['data']
@@ -135,13 +135,13 @@ def test_default_post_put_get():
     assert resp.status_code == 201
 
     put_data = {
-        "projectId":new_project['projectId'],
         "selectedBooks": {
             "bible": table_name,
             "books": ["luk", "jhn"]
           }
     }
-    response2b = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    response2b = client.put(UNIT_URL+'?project_id='+str(new_project['projectId']), \
+        headers=headers_auth, json=put_data)
     assert response2b.status_code == 201
     assert response2b.json()['message'] == "Project updated successfully"
     updated_project = response2b.json()['data']
@@ -166,9 +166,9 @@ def test_default_post_put_get():
 
     # change name
     put_data = {
-        "projectId":new_project['projectId'],
         "projectName":"New name for old project"}
-    response4 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    response4 = client.put(UNIT_URL+'?project_id='+str(new_project['projectId']),\
+         headers=headers_auth, json=put_data)
     assert response4.status_code == 201
     assert response4.json()['message'] == "Project updated successfully"
     updated_project = response4.json()['data']
@@ -290,19 +290,19 @@ def test_put_invalid():
     assert_input_validation_error(resp)
 
     # incorrect values in fields
-    data = {"projectId": new_project['projectId'],
-    "active": "delete"}
-    resp = client.put(UNIT_URL, headers=headers_auth, json=data)
+    data = {"active": "delete"}
+    resp = client.put(UNIT_URL+'?project_id='+str(new_project['projectId']),\
+         headers=headers_auth, json=data)
     assert_input_validation_error(resp)
 
-    data = {"projectId": new_project['projectId'],
-    "uploadedUSFMs": "mat"}
-    resp = client.put(UNIT_URL, headers=headers_auth, json=data)
+    data = {"uploadedUSFMs": "mat"}
+    resp = client.put(UNIT_URL+'?project_id='+str(new_project['projectId']),\
+         headers=headers_auth, json=data)
     assert_input_validation_error(resp)
 
-    data = {"projectId": new_project['projectId'],
-    "uploadedUSFMs": ["The contents of matthew in text"]}
-    resp = client.put(UNIT_URL, headers=headers_auth, json=data)
+    data = {"uploadedUSFMs": ["The contents of matthew in text"]}
+    resp = client.put(UNIT_URL+'?project_id='+str(new_project['projectId']),\
+         headers=headers_auth, json=data)
     assert resp.status_code == 415
     assert resp.json()['error'] == "Not the Required Type"
 
@@ -409,14 +409,14 @@ def test_update_user():
     assert resp.json()['message'] == "User added to project successfully"
 
     update_data = {
-        "project_id": new_project['projectId'],
         "userId": new_user_id
     }
 
     # change role
     update1 = update_data
     update1['userRole'] = 'projectOwner'
-    response1 = client.put(USER_URL, headers=headers_auth, json=update1)
+    response1 = client.put(USER_URL+'?project_id='+str(new_project['projectId']),\
+         headers=headers_auth, json=update1)
     assert response1.status_code == 201
     assert response1.json()['message'] == "User updated in project successfully"
     check_project_user(project_data['projectName'], new_user_id, role="projectOwner")
@@ -424,7 +424,8 @@ def test_update_user():
     # change status
     update2 = update_data
     update2['active'] = False
-    response2 = client.put(USER_URL, headers=headers_auth, json=update2)
+    response2 = client.put(USER_URL+'?project_id='+str(new_project['projectId']),\
+         headers=headers_auth, json=update2)
     assert response2.status_code == 201
     assert response2.json()['message'] == "User updated in project successfully"
     check_project_user(project_data['projectName'], new_user_id, status=False)
@@ -433,7 +434,8 @@ def test_update_user():
     meta = {"last_filter": "mat"}
     update3 = update_data
     update3['metaData'] = meta
-    response3 = client.put(USER_URL, headers=headers_auth, json=update3)
+    response3 = client.put(USER_URL+'?project_id='+str(new_project['projectId']),\
+         headers=headers_auth, json=update3)
     assert response3.status_code == 201
     assert response3.json()['message'] == "User updated in project successfully"
     check_project_user(project_data['projectName'], new_user_id, metadata=meta)
@@ -458,40 +460,40 @@ def test_update_user_invlaid():
 
     # not the added user
     update_data = {
-        "project_id": new_project['projectId'],
         "userId": "not-a-valid-user-11233",
         "active": False
     }
-    response = client.put(USER_URL, headers=headers_auth, json=update_data)
+    response = client.put(USER_URL+'?project_id='+str(new_project['projectId']),\
+         headers=headers_auth, json=update_data)
     assert response.status_code == 404
     assert response.json()['details'] == "User-project pair not found"
 
     #non existant project
     update_data = {
-        "project_id": new_project['projectId']+1,
         "userId": new_user_id,
         "active": False
     }
-    response = client.put(USER_URL, headers=headers_auth, json=update_data)
+    response = client.put(USER_URL+'?project_id='+str(new_project['projectId']+1),\
+         headers=headers_auth, json=update_data)
     assert response.status_code == 404
-    assert response.json()['details'] == f"Project with id, {update_data['project_id']}, not present"
+    assert response.json()['details'] == f"Project with id, {new_project['projectId']+1}, not present"
 
     # invalid status
     update_data = {
-        "project_id": new_project['projectId']+1,
         "userId": new_user_id,
         "active": "Delete"
     }
-    response = client.put(USER_URL, headers=headers_auth, json=update_data)
+    response = client.put(USER_URL+'?project_id='+str(new_project['projectId']+1),\
+         headers=headers_auth, json=update_data)
     assert_input_validation_error(response)
 
     # invalid metadata
     update_data = {
-        "project_id": new_project['projectId']+1,
         "userId": new_user_id,
         "metaData": "A normal string intead of json"
     }
-    response = client.put(USER_URL, headers=headers_auth, json=update_data)
+    response = client.put(USER_URL+'?project_id='+str(new_project['projectId']+1),\
+         headers=headers_auth, json=update_data)
     assert_input_validation_error(response)
 
 
@@ -547,7 +549,8 @@ def test_soft_delete():
 
         put_obj = {"active": False}
         put_obj['projectId'] = project_id
-        response = client.put(UNIT_URL, headers=headers_auth, json=put_obj)
+        response = client.put(UNIT_URL+'?project_id='+str(project_id),\
+             headers=headers_auth, json=put_obj)
         assert response.status_code == 201
         assert response.json()['message'] == 'Project updated successfully'
         assert not response.json()['data']['active']
@@ -650,12 +653,12 @@ def test_agmt_projects_access_rule():
 
     #update Project
     put_data = {
-    "projectId":project6_id,
     "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
     #update with Owner of project
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
-    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    response2 = client.put(UNIT_URL+'?project_id='+str(project6_id),\
+         headers=headers_auth, json=put_data)
     assert response2.status_code == 201
     assert response2.json()['message'] == "Project updated successfully"
     updated_project = response2.json()['data']
@@ -663,24 +666,25 @@ def test_agmt_projects_access_rule():
 
     #aguser project can be updated by super admin and Ag admin
     put_data = {
-        "projectId":project6_id,
         "projectName":"New name for old project6"}
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
-    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    response2 = client.put(UNIT_URL+'?project_id='+str(project6_id),\
+         headers=headers_auth, json=put_data)
     assert response2.status_code == 201
     assert response2.json()['message'] == "Project updated successfully"
     assert response2.json()['data']['projectName'] == put_data["projectName"]
     put_data["projectName"] = "New name for project7 by SA"
     headers_auth['Authorization'] = "Bearer"+" "+test_SA_token
-    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    response2 = client.put(UNIT_URL+'?project_id='+str(project6_id),\
+         headers=headers_auth, json=put_data)
     assert response2.status_code == 201
     assert response2.json()['message'] == "Project updated successfully"
     assert response2.json()['data']['projectName'] == put_data["projectName"]
 
     #update project with not Owner
-    put_data["projectId"] = project7_id
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
-    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    response2 = client.put(UNIT_URL+'?project_id='+str(project7_id),\
+         headers=headers_auth, json=put_data)
     assert response2.status_code == 403
     assert response2.json()['error'] == 'Permission Denied'
 
@@ -731,19 +735,20 @@ def test_agmt_projects_access_rule():
     #update user with not owner
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
     update_data = {
-        "project_id": project8_id,
         "userId": new_user_id
     }
     # add metadata
     meta = {"last_filter": "luk"}
     update_data['metaData'] = meta
-    response3 = client.put(USER_URL, headers=headers_auth, json=update_data)
+    response3 = client.put(USER_URL+'?project_id='+str(project8_id),\
+         headers=headers_auth, json=update_data)
     assert response3.status_code == 403
     assert response3.json()['error'] == 'Permission Denied'
     #update with owner
     post_data['projectName'] = 'Test project 1'
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
-    response3 = client.put(USER_URL, headers=headers_auth, json=update_data)
+    response3 = client.put(USER_URL+'?project_id='+str(project8_id),\
+         headers=headers_auth, json=update_data)
     assert response3.status_code == 201
     assert response3.json()['message'] == "User updated in project successfully"
 
@@ -909,10 +914,10 @@ def test_create_n_update_times():
 
     # Make an update to project
     update_data = {
-        "projectId": project_id,
         "metaData": {"last_filter": "luk"}
     }
-    response2 = client.put(UNIT_URL, headers=headers_auth, json=update_data)
+    response2 = client.put(UNIT_URL+'?project_id='+str(project_id),\
+         headers=headers_auth, json=update_data)
     assert response2.status_code == 201
     assert response2.json()['message'] == "Project updated successfully"
 
@@ -1302,12 +1307,12 @@ def test_bugfix_split_n_merged_verse():
     project_id = response.json()['data']['projectId']
 
     prj_book_data = {
-      "projectId": project_id,
       "uploadedUSFMs": [
           "\\id REV\n\\c 1\n\\p\n\\v 1 some text\n\\v 2-10 merged text\n\\v 11a split text\n\\v 11b rest"
       ]
     }
-    prj_update_resp = client.put(UNIT_URL, json=prj_book_data, headers=headers_auth)
+    prj_update_resp = client.put(UNIT_URL+'?project_id='+str(project_id),\
+         json=prj_book_data, headers=headers_auth)
     assert prj_update_resp.status_code == 201
     resp_obj = prj_update_resp.json()
     assert resp_obj['message'] == 'Project updated successfully'
@@ -1326,7 +1331,7 @@ def test_bugfix_split_n_merged_verse():
     assert sentences[2]['surrogateId'] == 'rev 1:11a-b'
     assert sentences[2]["sentence"] == 'split text rest'
 
-def test_app_compatibility():
+def test_post_put_app_compatibility():
     '''Positive test to check app compatibility
     * Only Autographa app can access translation APIs'''
     headers_auth = {"contentType": "application/json",
@@ -1339,10 +1344,25 @@ def test_app_compatibility():
     post_data = {
     "projectName": "Test project 1",
     "sourceLanguageCode": "hi",
-    "targetLanguageCode": "ml",
-    "compatibleWith": ["SanketMAST","Autographa"]
+    "targetLanguageCode": "ml"
     }
-    # Creating new project with compatible app - Positive Test
+
+    #Creating new project with out adding compatibleWith field - Positive Test
+    #app value in the header will be auto assigned as compatibleWith field
+    response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
+    assert response.status_code == 201
+    assert response.json()['message'] == "Project created successfully"
+    response.json()['data']['compatibleWith'] = ["Autographa"]
+    assert_positive_get( response.json()['data'])
+
+    # Creating new project with compatible app which is not passed as a list - Negative Test
+    post_data['compatibleWith'] = "Autographa"
+    response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
+    assert_input_validation_error(response)
+
+    # Creating new project with compatible app passed as a list - Positive Test
+    post_data["projectName"] = "Test Project 2"
+    post_data["compatibleWith"] = ["SanketMAST","Autographa"]
     response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
     assert response.status_code == 201
     assert response.json()['message'] == "Project created successfully"
@@ -1356,18 +1376,33 @@ def test_app_compatibility():
     assert new_project['active']
 
     # Create new project with incompatible app - Negative Test
-    post_data['compatibleWith'] = ['SanketMAST']
-    response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
+    post_data_2= {
+    "projectName": "Test project 3",
+    "sourceLanguageCode": "hi",
+    "targetLanguageCode": "ml",
+    "compatibleWith": ["SanketMAST"]
+    }
+    response = client.post(UNIT_URL, headers=headers_auth, json=post_data_2)
     assert response.status_code == 403
     assert response.json()['details'] == "Incompatible app"
 
-    # update data with compatible app - positive test
+    # update data with compatible app not passed as a list - negative test
+
     put_data = {
-    "projectId":new_project['projectId'],
-    "uploadedUSFMs":[bible_books['mat']],
-    "compatibleWith": ["SanketMAST","VachanAdmin"]
+    "uploadedUSFMs":[bible_books['mat']]
     }
-    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    put_data["compatibleWith"] =  "Autographa"
+    response2 = client.put(UNIT_URL+'?project_id='+str(new_project['projectId']),\
+         headers=headers_auth, json=put_data)
+    assert_input_validation_error(response2)
+
+    # update data with compatible app passed as a list - positive test
+    put_data = {
+    "uploadedUSFMs":[bible_books['mat']]
+    }
+    put_data["compatibleWith"] =  ["SanketMAST","VachanAdmin"]
+    response2 = client.put(UNIT_URL+'?project_id='+str(new_project['projectId']), \
+        headers=headers_auth, json=put_data)
     assert response2.status_code == 201
     assert response2.json()['message'] == "Project updated successfully"
     updated_project = response2.json()['data']
@@ -1379,11 +1414,10 @@ def test_app_compatibility():
 
     # update project with incompatible app - Negative Test
     put_data = {
-    "projectId":new_project['projectId'],
     "uploadedUSFMs":[bible_books['mrk']],
     "compatibleWith": ["VachanAdmin"]
     }
-    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    response2 = client.put(UNIT_URL+'?project_id='+str(new_project['projectId']), headers=headers_auth, json=put_data)
     assert response2.status_code == 403
     assert response2.json()['details'] == "Incompatible app"
 
@@ -1416,10 +1450,9 @@ def test_delete_with_compatible_app():
     assert resp.json()['message'] == f"Project with identity {project_id_1} deleted successfully"
     # update compatibility of project 2
     put_data = {
-    "projectId":project_id_2,
     "compatibleWith": ["VachanAdmin"]
     }
-    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    response2 = client.put(UNIT_URL+'?project_id='+str(project_id_2), headers=headers_auth, json=put_data)
 
     # delete project with incompatible app - Negative Test
     resp = client.delete(UNIT_URL+'?project_id='+str(project_id_2),headers=headers_auth)
@@ -1453,14 +1486,26 @@ def test_get_filter_with_app_compatibility():
     # Creating new project with multiple items in compatible_with field - Positive test
     response3 = client.post(UNIT_URL, headers=headers_auth, json=data_3)
    
+    #filtering with single app - passing app not as a list - Negative test
+    app = "Autographa"
+    params = []
+    for item in app:
+        params.append(("compatible_with", item))
+    get_resp = client.get(UNIT_URL ,params=params,headers=headers_auth)
+    assert_input_validation_error(get_resp)
+    
     # filtering with single app - positive test
-    get_resp = client.get(UNIT_URL + "?compatible_with=Autographa",headers=headers_auth)
+    app = ["Autographa"]
+    params = []
+    for item in app:
+        params.append(("compatible_with", item))
+    get_resp = client.get(UNIT_URL ,params=params,headers=headers_auth)
     for item in get_resp.json():
         assert_positive_get(item)
     assert len(get_resp.json()) == 3
-    assert"Autographa" in  get_resp.json()[0]['compatibleWith']
-    assert"Autographa" in  get_resp.json()[1]['compatibleWith']
-    assert"Autographa" in  get_resp.json()[2]['compatibleWith']
+    assert "Autographa" in  get_resp.json()[0]['compatibleWith']
+    assert "Autographa" in  get_resp.json()[1]['compatibleWith']
+    assert "Autographa" in  get_resp.json()[2]['compatibleWith']
 
     #filtering with multiple apps - positive test
     app_list = [schema_auth.App.SMAST.value, schema_auth.App.AG.value]

--- a/app/test/test_agmt_translation.py
+++ b/app/test/test_agmt_translation.py
@@ -57,10 +57,10 @@ def test_get_tokens():
     assert_not_available_content(get_response1)
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     # after adding books
@@ -154,7 +154,7 @@ def test_tokenization_invalid():
     # non existant project
     response = client.get(UNIT_URL+"/tokens?project_id="+str(project_id+1),headers=headers_auth)
     assert response.status_code == 404
-    assert response.json()['details'] == "Project with id, %s, not found"%(project_id+1)
+    assert response.json()['details'] == "Project with id, %s, not present"%(project_id+1)
 
     #invalid book
     response = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+"&books=mmm"
@@ -197,11 +197,11 @@ def test_save_translation():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
 
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+        headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     resp = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
@@ -270,10 +270,10 @@ def test_save_translation_invalid():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+        headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     resp = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
@@ -351,10 +351,10 @@ def test_drafts():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+        headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     resp = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
@@ -409,10 +409,10 @@ def test_get_token_sentences():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+        headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     resp = client.get("/v2/text/translate/token-based/project/tokens?project_id="+str(project_id)
@@ -478,10 +478,10 @@ def test_get_sentence():
     assert_not_available_content(response)
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+        headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     # before translation
@@ -558,10 +558,10 @@ def test_progress_n_suggestion():
     assert response.json()['suggestion'] == 0
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+        headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     # before translation
@@ -635,10 +635,10 @@ def test_get_versification():
         assert len(response.json()[key]) == 0
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+        headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     response = client.get(UNIT_URL+"/versification?project_id="+str(project_id)
@@ -671,10 +671,10 @@ def test_agmt_translation_access_rule_app():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+        headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     #get tokens
@@ -841,10 +841,10 @@ def test_data_updated_time():
 
     # Add book into empty project
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+        headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     # Get tokens
@@ -920,10 +920,10 @@ def test_agmt_translation_access_permissions():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+        headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     resp = client.get("/v2/text/translate/token-based/project/tokens?project_id="+str(project_id)

--- a/app/test/test_agmt_translation2.py
+++ b/app/test/test_agmt_translation2.py
@@ -44,11 +44,11 @@ def test_draft_update_positive():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "sentenceList":source_sentences
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     resp = client.get(f"{UNIT_URL}/sentences?project_id={project_id}", headers=headers_auth)
@@ -158,11 +158,11 @@ def test_draft_update_negative():
 
     # upload source and repeat last action
     put_data_source = {
-        "projectId": project_id,
         "sentenceList":source_sentences
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data_source)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data_source)
     assert resp.json()['message'] == "Project updated successfully"
 
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
@@ -241,11 +241,11 @@ def test_empty_draft_initalization():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "sentenceList":source_sentences
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     # Ensure draft is set to ""
@@ -297,11 +297,11 @@ def test_draft_meta_validation():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "sentenceList":source_sentences
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     #Get suggestions
@@ -334,11 +334,11 @@ def test_space_in_suggested_draft():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "sentenceList":source_sentences
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     # Add a gloss to ensure some suggestion in output
@@ -378,11 +378,11 @@ def test_delete_sentence():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "sentenceList":source_sentences
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     # Check sentences are added
@@ -460,11 +460,11 @@ def test_restore_sentence():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "sentenceList":source_sentences
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     delete_resp =client.delete(f"{UNIT_URL}/sentences?project_id={project_id}&sentence_id=100",
             headers=headers_auth)
 
@@ -535,7 +535,6 @@ def test_suggestion_when_token_overlaps_confirmed_segment():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "sentenceList": [
             {
             "sentenceId": 57001002,
@@ -545,7 +544,8 @@ def test_suggestion_when_token_overlaps_confirmed_segment():
         ]
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     # add a translation for just "not" when it occurs as "doesnot"
@@ -622,11 +622,11 @@ def test_glossupdate_upon_draft_update():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "sentenceList":source_sentences
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     resp = client.get(f"{UNIT_URL}/sentences?project_id={project_id}", headers=headers_auth)
@@ -664,11 +664,11 @@ def test_draftmeta_validation():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "sentenceList":source_sentences
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     ## Spaces not accounted for

--- a/app/test/test_agmt_translation2.py
+++ b/app/test/test_agmt_translation2.py
@@ -148,7 +148,7 @@ def test_draft_update_negative():
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
     resp = client.put(f"/v2/text/translate/token-based/project/draft?project_id={project_id+1}",
         headers=headers_auth, json=put_data)
-    assert resp.json()['error'] == "Requested Content Not Available"
+    assert resp.json()['details'] == f"Project with id, {project_id+1}, not present"
 
     # non existing sentence
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']

--- a/app/test/test_smast_projects.py
+++ b/app/test/test_smast_projects.py
@@ -91,10 +91,10 @@ def test_default_post_put_get():
 
     # upload books
     put_data = {
-    "projectId":new_project['projectId'],
     "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    response2 = client.put(UNIT_URL+'?project_id='+str(new_project['projectId']),\
+         headers=headers_auth, json=put_data)
     assert response2.status_code == 201
     assert response2.json()['message'] == "Project updated successfully"
     updated_project = response2.json()['data']
@@ -135,13 +135,13 @@ def test_default_post_put_get():
     assert resp.status_code == 201
 
     put_data = {
-        "projectId":new_project['projectId'],
         "selectedBooks": {
             "bible": table_name,
             "books": ["luk", "jhn"]
           }
     }
-    response2b = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    response2b = client.put(UNIT_URL+'?project_id='+str(new_project['projectId']),\
+         headers=headers_auth, json=put_data)
     assert response2b.status_code == 201
     assert response2b.json()['message'] == "Project updated successfully"
     updated_project = response2b.json()['data']
@@ -166,9 +166,9 @@ def test_default_post_put_get():
 
     # change name
     put_data = {
-        "projectId":new_project['projectId'],
         "projectName":"New name for old project"}
-    response4 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    response4 = client.put(UNIT_URL+'?project_id='+str(new_project['projectId']),\
+         headers=headers_auth, json=put_data)
     assert response4.status_code == 201
     assert response4.json()['message'] == "Project updated successfully"
     updated_project = response4.json()['data']
@@ -290,19 +290,19 @@ def test_put_invalid():
     assert_input_validation_error(resp)
 
     # incorrect values in fields
-    data = {"projectId": new_project['projectId'],
-    "active": "delete"}
-    resp = client.put(UNIT_URL, headers=headers_auth, json=data)
+    data = {"active": "delete"}
+    resp = client.put(UNIT_URL+'?project_id='+str(new_project['projectId']), \
+        headers=headers_auth, json=data)
     assert_input_validation_error(resp)
 
-    data = {"projectId": new_project['projectId'],
-    "uploadedUSFMs": "mat"}
-    resp = client.put(UNIT_URL, headers=headers_auth, json=data)
+    data = {"uploadedUSFMs": "mat"}
+    resp = client.put(UNIT_URL+'?project_id='+str(new_project['projectId']), \
+        headers=headers_auth, json=data)
     assert_input_validation_error(resp)
 
-    data = {"projectId": new_project['projectId'],
-    "uploadedUSFMs": ["The contents of matthew in text"]}
-    resp = client.put(UNIT_URL, headers=headers_auth, json=data)
+    data = {"uploadedUSFMs": ["The contents of matthew in text"]}
+    resp = client.put(UNIT_URL+'?project_id='+str(new_project['projectId']), \
+        headers=headers_auth, json=data)
     assert resp.status_code == 415
     assert resp.json()['error'] == "Not the Required Type"
 
@@ -410,14 +410,16 @@ def test_update_user():
     assert resp.json()['message'] == "User added to project successfully"
 
     update_data = {
-        "project_id": new_project['projectId'],
+        # "project_id": new_project['projectId'],
         "userId": new_user_id
     }
 
     # change role
     update1 = update_data
     update1['userRole'] = 'projectOwner'
-    response1 = client.put(USER_URL, headers=headers_auth, json=update1)
+    # response1 = client.post(USER_URL+'?project_id='+str(new_project['projectId'])+
+    #     '&user_id='+str(new_user_id),headers=headers_auth)
+    response1 = client.put(USER_URL+'?project_id='+str(new_project['projectId']), headers=headers_auth, json=update1)
     assert response1.status_code == 201
     assert response1.json()['message'] == "User updated in project successfully"
     check_project_user(project_data['projectName'], new_user_id, role="projectOwner")
@@ -425,7 +427,7 @@ def test_update_user():
     # change status
     update2 = update_data
     update2['active'] = False
-    response2 = client.put(USER_URL, headers=headers_auth, json=update2)
+    response2 = client.put(USER_URL+'?project_id='+str(new_project['projectId']), headers=headers_auth, json=update2)
     assert response2.status_code == 201
     assert response2.json()['message'] == "User updated in project successfully"
     check_project_user(project_data['projectName'], new_user_id, status=False)
@@ -434,7 +436,7 @@ def test_update_user():
     meta = {"last_filter": "mat"}
     update3 = update_data
     update3['metaData'] = meta
-    response3 = client.put(USER_URL, headers=headers_auth, json=update3)
+    response3 = client.put(USER_URL+'?project_id='+str(new_project['projectId']), headers=headers_auth, json=update3)
     assert response3.status_code == 201
     assert response3.json()['message'] == "User updated in project successfully"
     check_project_user(project_data['projectName'], new_user_id, metadata=meta)
@@ -451,7 +453,7 @@ def test_update_user_invlaid():
     assert resp.json()['message'] == "Project created successfully"
     new_project = resp.json()['data']
     new_user_id = initial_test_users['SanketMASTUser']['test_user_id']
-
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     resp = client.post(USER_URL+'?project_id='+str(new_project['projectId'])+
         '&user_id='+str(new_user_id),headers=headers_auth)
     assert resp.json()['message'] == "User added to project successfully"
@@ -459,41 +461,38 @@ def test_update_user_invlaid():
 
     # not the added user
     update_data = {
-        "project_id": new_project['projectId'],
         "userId": "not-a-valid-user-11233",
         "active": False
     }
-    response = client.put(USER_URL, headers=headers_auth, json=update_data)
+    response = client.put(USER_URL+'?project_id='+str(new_project['projectId']), headers=headers_auth, json=update_data)
     assert response.status_code == 404
     assert response.json()['details'] == "User-project pair not found"
 
     #non existant project
     update_data = {
-        "project_id": new_project['projectId']+1,
         "userId": new_user_id,
         "active": False
     }
-    response = client.put(USER_URL, headers=headers_auth, json=update_data)
+    response = client.put(USER_URL+'?project_id='+str(new_project['projectId']+1), headers=headers_auth, json=update_data)
+    print("non existant:",response.json())
     assert response.status_code == 404
-    assert response.json()['details'] == f"Project with id, {update_data['project_id']}, not present"
+    assert response.json()['details'] == f"Project with id, {new_project['projectId']+1}, not present"
 
 
     # invalid status
     update_data = {
-        "project_id": new_project['projectId']+1,
         "userId": new_user_id,
         "active": "Delete"
     }
-    response = client.put(USER_URL, headers=headers_auth, json=update_data)
+    response = client.put(USER_URL+'?project_id='+str(new_project['projectId']+1), headers=headers_auth, json=update_data)
     assert_input_validation_error(response)
 
     # invalid metadata
     update_data = {
-        "project_id": new_project['projectId']+1,
         "userId": new_user_id,
         "metaData": "A normal string intead of json"
     }
-    response = client.put(USER_URL, headers=headers_auth, json=update_data)
+    response = client.put(USER_URL+'?project_id='+str(new_project['projectId']+1), headers=headers_auth, json=update_data)
     assert_input_validation_error(response)
 
 
@@ -548,8 +547,7 @@ def test_soft_delete():
         project_id = resp.json()[0]['projectId']
 
         put_obj = {"active": False}
-        put_obj['projectId'] = project_id
-        response = client.put(UNIT_URL, headers=headers_auth, json=put_obj)
+        response = client.put(UNIT_URL+'?project_id='+str(project_id), headers=headers_auth, json=put_obj)
         assert response.status_code == 201
         assert response.json()['message'] == 'Project updated successfully'
         assert not response.json()['data']['active']
@@ -644,12 +642,11 @@ def test_agmt_projects_access_rule():
 
     #update Project
     put_data = {
-    "projectId":project6_id,
     "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
     #update with Owner of project
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
-    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    response2 = client.put(UNIT_URL+'?project_id='+str(project6_id), headers=headers_auth, json=put_data)
     assert response2.status_code == 201
     assert response2.json()['message'] == "Project updated successfully"
     updated_project = response2.json()['data']
@@ -657,24 +654,22 @@ def test_agmt_projects_access_rule():
 
     #aguser project can be updated by super admin and SanketMAST admin
     put_data = {
-        "projectId":project6_id,
         "projectName":"New name for old project6"}
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
-    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    response2 = client.put(UNIT_URL+'?project_id='+str(project6_id), headers=headers_auth, json=put_data)
     assert response2.status_code == 201
     assert response2.json()['message'] == "Project updated successfully"
     assert response2.json()['data']['projectName'] == put_data["projectName"]
     put_data["projectName"] = "New name for project7 by SA"
     headers_auth['Authorization'] = "Bearer"+" "+test_SA_token
-    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    response2 = client.put(UNIT_URL+'?project_id='+str(project6_id), headers=headers_auth, json=put_data)
     assert response2.status_code == 201
     assert response2.json()['message'] == "Project updated successfully"
     assert response2.json()['data']['projectName'] == put_data["projectName"]
 
     #update project with not Owner
-    put_data["projectId"] = project7_id
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
-    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    response2 = client.put(UNIT_URL+'?project_id='+str(project7_id), headers=headers_auth, json=put_data)
     assert response2.status_code == 403
     assert response2.json()['error'] == 'Permission Denied'
 
@@ -725,19 +720,18 @@ def test_agmt_projects_access_rule():
     #update user with not owner
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
     update_data = {
-        "project_id": project8_id,
         "userId": new_user_id
     }
     # add metadata
     meta = {"last_filter": "luk"}
     update_data['metaData'] = meta
-    response3 = client.put(USER_URL, headers=headers_auth, json=update_data)
+    response3 = client.put(USER_URL+'?project_id='+str(project8_id), headers=headers_auth, json=update_data)
     assert response3.status_code == 403
     assert response3.json()['error'] == 'Permission Denied'
     #update with owner
     post_data['projectName'] = 'Test project 1'
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
-    response3 = client.put(USER_URL, headers=headers_auth, json=update_data)
+    response3 = client.put(USER_URL+'?project_id='+str(project8_id), headers=headers_auth, json=update_data)
     assert response3.status_code == 201
     assert response3.json()['message'] == "User updated in project successfully"
 
@@ -893,10 +887,9 @@ def test_create_n_update_times():
 
     # Make an update to project
     update_data = {
-        "projectId": project_id,
         "metaData": {"last_filter": "luk"}
     }
-    response2 = client.put(UNIT_URL, headers=headers_auth, json=update_data)
+    response2 = client.put(UNIT_URL+'?project_id='+str(project_id), headers=headers_auth, json=update_data)
     assert response2.status_code == 201
     assert response2.json()['message'] == "Project updated successfully"
 
@@ -1285,12 +1278,11 @@ def test_bugfix_split_n_merged_verse():
     project_id = response.json()['data']['projectId']
 
     prj_book_data = {
-      "projectId": project_id,
       "uploadedUSFMs": [
           "\\id REV\n\\c 1\n\\p\n\\v 1 some text\n\\v 2-10 merged text\n\\v 11a split text\n\\v 11b rest"
       ]
     }
-    prj_update_resp = client.put(UNIT_URL, json=prj_book_data, headers=headers_auth)
+    prj_update_resp = client.put(UNIT_URL+'?project_id='+str(project_id), json=prj_book_data, headers=headers_auth)
     assert prj_update_resp.status_code == 201
     resp_obj = prj_update_resp.json()
     assert resp_obj['message'] == 'Project updated successfully'
@@ -1309,7 +1301,7 @@ def test_bugfix_split_n_merged_verse():
     assert sentences[2]['surrogateId'] == 'rev 1:11a-b'
     assert sentences[2]["sentence"] == 'split text rest'
 
-def test_app_compatibility():
+def test_post_put_app_compatibility():
     '''Positive test to check app compatibility
     * Only SanketMAST app can access translation APIs'''
     headers_auth = {"contentType": "application/json",
@@ -1322,10 +1314,25 @@ def test_app_compatibility():
     post_data = {
     "projectName": "Test project 1",
     "sourceLanguageCode": "hi",
-    "targetLanguageCode": "ml",
-    "compatibleWith": ["SanketMAST","Autographa"]
+    "targetLanguageCode": "ml"
     }
-    # Creating new project with compatible app - Positive Test
+
+    #Creating new project with out adding compatibleWith field - Positive Test
+    #app value in the header will be auto assigned as compatibleWith field
+    response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
+    assert response.status_code == 201
+    assert response.json()['message'] == "Project created successfully"
+    response.json()['data']['compatibleWith'] = ["SanketMAST"]
+    assert_positive_get( response.json()['data'])
+
+    # Creating new project with compatible app which is not passed as a list - Negative Test
+    post_data['compatibleWith'] = "SanketMAST"
+    response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
+    assert_input_validation_error(response)
+
+    # Creating new project with compatible app passed as a list - Positive Test
+    post_data["projectName"] = "Test Project 2"
+    post_data["compatibleWith"] = ["SanketMAST","Autographa"]
     response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
     assert response.status_code == 201
     assert response.json()['message'] == "Project created successfully"
@@ -1339,18 +1346,32 @@ def test_app_compatibility():
     assert new_project['active']
 
     # Create new project with incompatible app - Negative Test
-    post_data['compatibleWith'] = ['Autographa']
-    response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
+    post_data_2= {
+    "projectName": "Test project 3",
+    "sourceLanguageCode": "hi",
+    "targetLanguageCode": "ml",
+    "compatibleWith": ["Autographa"]
+    }
+    response = client.post(UNIT_URL, headers=headers_auth, json=post_data_2)
     assert response.status_code == 403
     assert response.json()['details'] == "Incompatible app"
 
-    # update data with compatible app - positive test
+    # update data with compatible app not passed as a list - negative test
     put_data = {
-    "projectId":new_project['projectId'],
-    "uploadedUSFMs":[bible_books['mat']],
-    "compatibleWith": ["Autographa","VachanAdmin"]
+    "uploadedUSFMs":[bible_books['mat']]
     }
-    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    put_data["compatibleWith"] =  "SanketMAST"
+    response2 = client.put(UNIT_URL+'?project_id='+str(new_project['projectId']),\
+         headers=headers_auth, json=put_data)
+    assert_input_validation_error(response2)
+
+    # update data with compatible app passed as a list - positive test
+    put_data = {
+    "uploadedUSFMs":[bible_books['mat']]
+    }
+    put_data["compatibleWith"] =  ["Autographa","VachanAdmin"]
+    response2 = client.put(UNIT_URL+'?project_id='+str(new_project['projectId']), \
+        headers=headers_auth, json=put_data)
     assert response2.status_code == 201
     assert response2.json()['message'] == "Project updated successfully"
     updated_project = response2.json()['data']
@@ -1362,11 +1383,11 @@ def test_app_compatibility():
 
     # update project with incompatible app - Negative Test
     put_data = {
-    "projectId":new_project['projectId'],
     "uploadedUSFMs":[bible_books['mrk']],
     "compatibleWith": ["VachanAdmin"]
     }
-    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    response2 = client.put(UNIT_URL+'?project_id='+str(new_project['projectId']), \
+        headers=headers_auth, json=put_data)
     assert response2.status_code == 403
     assert response2.json()['details'] == "Incompatible app"
 
@@ -1399,10 +1420,10 @@ def test_delete_with_compatible_app():
     assert resp.json()['message'] == f"Project with identity {project_id_1} deleted successfully"
     # update compatibility of project 2
     put_data = {
-    "projectId":project_id_2,
     "compatibleWith": ["VachanAdmin"]
     }
-    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    response2 = client.put(UNIT_URL+'?project_id='+str(project_id_2), \
+        headers=headers_auth, json=put_data)
 
     # delete project with incompatible app - Negative Test
     resp = client.delete(UNIT_URL+'?project_id='+str(project_id_2),headers=headers_auth)
@@ -1435,9 +1456,21 @@ def test_get_filter_with_app_compatibility():
     response2 = client.post(UNIT_URL, headers=headers_auth, json=data_2)
     # Creating new project with multiple items in compatible_with field - Positive test
     response3 = client.post(UNIT_URL, headers=headers_auth, json=data_3)
-   
+    
+    #filtering with single app - passing app not as a list - Negative test
+    app = "SanketMAST"
+    params = []
+    for item in app:
+        params.append(("compatible_with", item))
+    get_resp = client.get(UNIT_URL ,params=params,headers=headers_auth)
+    assert_input_validation_error(get_resp)
+    
     # filtering with single app - positive test
-    get_resp = client.get(UNIT_URL + "?compatible_with=SanketMAST",headers=headers_auth)
+    app = ["SanketMAST"]
+    params = []
+    for item in app:
+        params.append(("compatible_with", item))
+    get_resp = client.get(UNIT_URL ,params=params,headers=headers_auth)
     for item in get_resp.json():
         assert_positive_get(item)
     assert len(get_resp.json()) == 3

--- a/app/test/test_smast_projects.py
+++ b/app/test/test_smast_projects.py
@@ -474,7 +474,6 @@ def test_update_user_invlaid():
         "active": False
     }
     response = client.put(USER_URL+'?project_id='+str(new_project['projectId']+1), headers=headers_auth, json=update_data)
-    print("non existant:",response.json())
     assert response.status_code == 404
     assert response.json()['details'] == f"Project with id, {new_project['projectId']+1}, not present"
 
@@ -1344,17 +1343,6 @@ def test_post_put_app_compatibility():
     assert isinstance(new_project['metaData']['books'], list)
     assert len(new_project['metaData']['books']) == 0
     assert new_project['active']
-
-    # Create new project with incompatible app - Negative Test
-    post_data_2= {
-    "projectName": "Test project 3",
-    "sourceLanguageCode": "hi",
-    "targetLanguageCode": "ml",
-    "compatibleWith": ["Autographa"]
-    }
-    response = client.post(UNIT_URL, headers=headers_auth, json=post_data_2)
-    assert response.status_code == 403
-    assert response.json()['details'] == "Incompatible app"
 
     # update data with compatible app not passed as a list - negative test
     put_data = {

--- a/app/test/test_smast_projects.py
+++ b/app/test/test_smast_projects.py
@@ -8,7 +8,7 @@ from .test_versions import check_post as add_version
 from .conftest import initial_test_users
 from . test_auth_basic import login,SUPER_PASSWORD,SUPER_USER,logout_user
 
-UNIT_URL = '/v2/text/translate/token-based/projects' 
+UNIT_URL = '/v2/text/translate/token-based/projects'
 USER_URL = '/v2/text/translate/token-based/project/user'
 SENTENCE_URL = '/v2/text/translate/token-based/project/sentences'
 RESTORE_URL = '/v2/admin/restore'
@@ -1305,3 +1305,89 @@ def test_bugfix_split_n_merged_verse():
     assert sentences[2]['sentenceId'] == 67001011
     assert sentences[2]['surrogateId'] == 'rev 1:11a-b'
     assert sentences[2]["sentence"] == 'split text rest'
+
+def test_app_compatibility():
+    '''Positive test to check app compatibility
+    * Only SanketMAST app can access translation APIs'''
+    headers_auth = {"contentType": "application/json",
+                "accept": "application/json",
+                "app":"SanketMAST"
+            }
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+
+    # create with minimum data
+    post_data = {
+    "projectName": "Test project 1",
+    "sourceLanguageCode": "hi",
+    "targetLanguageCode": "ml",
+    "compatibleWith": "SanketMAST"
+    }
+    # Creating new project with compatible app - Negative Test
+    response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
+    assert response.status_code == 201
+    assert response.json()['message'] == "Project created successfully"
+    new_project = response.json()['data']
+    assert_positive_get(new_project)
+
+    # check if all defaults are coming
+    assert new_project['metaData']["useDataForLearning"]
+    assert isinstance(new_project['metaData']['books'], list)
+    assert len(new_project['metaData']['books']) == 0
+    assert new_project['active']
+
+    # Create new project with incompatible app - Negative Test
+    post_data['compatibleWith'] = 'Autographa'
+    response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
+    assert response.status_code == 403
+    assert response.json()['details'] == "Incompatible app"
+
+    # update data with compatible app - positive test
+    put_data = {
+    "projectId":new_project['projectId'],
+    "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']],
+    "compatibleWith": "SanketMAST"
+    }
+    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    assert response2.status_code == 201
+    assert response2.json()['message'] == "Project updated successfully"
+    updated_project = response2.json()['data']
+    assert_positive_get(updated_project)
+
+    assert new_project['projectId'] == updated_project['projectId']
+    assert new_project['projectName'] == updated_project['projectName']
+    assert updated_project['metaData']['books'] == ['mat', 'mrk']
+
+    # update project with incompatible app - Negative Test
+    put_data = {
+    "projectId":new_project['projectId'],
+    "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']],
+    "compatibleWith": "Autographa"
+    }
+    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+    assert response.status_code == 403
+    assert response.json()['details'] == "Incompatible app"
+
+def test_get_filter_with_app_compatibility():
+    '''Test  to filter with app compatibility'''
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    data_1 = {
+    "projectName": "Test project 1",
+    "sourceLanguageCode": "hi",
+    "targetLanguageCode": "ml",
+    "compatibleWith": "SanketMAST"
+    }
+    data_2 = {
+    "projectName": "Test project 2",
+    "sourceLanguageCode": "hi",
+    "targetLanguageCode": "ml"
+    }
+    # Creating new project with compatible app - Negative Test
+    response1 = client.post(UNIT_URL, headers=headers_auth, json=data_1)
+    response2 = client.post(UNIT_URL, headers=headers_auth, json=data_2)
+    get_resp = client.get(UNIT_URL+'?compatible_with=SanketMAST',headers=headers_auth)
+    for item in get_resp.json():
+        assert_positive_get(item)
+    assert len(get_resp.json()) == 2
+    assert get_resp.json()[0]['compatibleWith'] == 'SanketMAST'
+    assert get_resp.json()[1]['compatibleWith'] == 'SanketMAST'
+   

--- a/app/test/test_smast_projects.py
+++ b/app/test/test_smast_projects.py
@@ -1,4 +1,5 @@
 '''Test cases for SanketMAST projects related APIs'''
+from schema import schema_auth
 from . import client
 from . import assert_input_validation_error, assert_not_available_content
 from . import check_default_get
@@ -401,6 +402,7 @@ def test_update_user():
     resp = check_post(project_data)
     assert resp.json()['message'] == "Project created successfully"
     new_project = resp.json()['data']
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     new_user_id = initial_test_users['SanketMASTUser']['test_user_id']
 
     resp = client.post(USER_URL+'?project_id='+str(new_project['projectId'])+
@@ -473,7 +475,8 @@ def test_update_user_invlaid():
     }
     response = client.put(USER_URL, headers=headers_auth, json=update_data)
     assert response.status_code == 404
-    assert response.json()['details'] == "User-project pair not found"
+    assert response.json()['details'] == f"Project with id, {update_data['project_id']}, not present"
+
 
     # invalid status
     update_data = {
@@ -943,7 +946,7 @@ def test_delete_project():
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     resp = client.delete(UNIT_URL+'?project_id='+str(invalid_project_id),headers=headers_auth)
     assert resp.status_code == 404
-    assert resp.json()['details'] == f"Project with id {invalid_project_id} not found"
+    assert resp.json()['details'] == f"Project with id, {invalid_project_id}, not present"
 
     # Delete as unauthorized users
     for user in ['APIUser','VachanAdmin','VachanUser','BcsDev','VachanContentAdmin','VachanContentViewer']:
@@ -1320,9 +1323,9 @@ def test_app_compatibility():
     "projectName": "Test project 1",
     "sourceLanguageCode": "hi",
     "targetLanguageCode": "ml",
-    "compatibleWith": "SanketMAST"
+    "compatibleWith": ["SanketMAST","Autographa"]
     }
-    # Creating new project with compatible app - Negative Test
+    # Creating new project with compatible app - Positive Test
     response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
     assert response.status_code == 201
     assert response.json()['message'] == "Project created successfully"
@@ -1336,7 +1339,7 @@ def test_app_compatibility():
     assert new_project['active']
 
     # Create new project with incompatible app - Negative Test
-    post_data['compatibleWith'] = 'Autographa'
+    post_data['compatibleWith'] = ['Autographa']
     response = client.post(UNIT_URL, headers=headers_auth, json=post_data)
     assert response.status_code == 403
     assert response.json()['details'] == "Incompatible app"
@@ -1344,8 +1347,8 @@ def test_app_compatibility():
     # update data with compatible app - positive test
     put_data = {
     "projectId":new_project['projectId'],
-    "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']],
-    "compatibleWith": "SanketMAST"
+    "uploadedUSFMs":[bible_books['mat']],
+    "compatibleWith": ["Autographa","VachanAdmin"]
     }
     response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
     assert response2.status_code == 201
@@ -1355,17 +1358,56 @@ def test_app_compatibility():
 
     assert new_project['projectId'] == updated_project['projectId']
     assert new_project['projectName'] == updated_project['projectName']
-    assert updated_project['metaData']['books'] == ['mat', 'mrk']
+    assert updated_project['metaData']['books'] == ['mat']
 
     # update project with incompatible app - Negative Test
     put_data = {
     "projectId":new_project['projectId'],
-    "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']],
-    "compatibleWith": "Autographa"
+    "uploadedUSFMs":[bible_books['mrk']],
+    "compatibleWith": ["VachanAdmin"]
     }
     response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
-    assert response.status_code == 403
-    assert response.json()['details'] == "Incompatible app"
+    assert response2.status_code == 403
+    assert response2.json()['details'] == "Incompatible app"
+
+def test_delete_with_compatible_app():
+    '''Test to delete project based on app compatibiblty'''
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    data_1 = {
+    "projectName": "Test project 1",
+    "sourceLanguageCode": "hi",
+    "targetLanguageCode": "ml",
+    "compatibleWith": ["SanketMAST"]
+    }
+    data_2 = {
+    "projectName": "Test project 2",
+    "sourceLanguageCode": "hi",
+    "targetLanguageCode": "ml",
+    "compatibleWith": ["SanketMAST","Autographa"]
+    }
+    # creating two projects
+    response1 = client.post(UNIT_URL, headers=headers_auth, json=data_1)
+    project1 = response1.json()['data']
+    project_id_1 = project1['projectId']
+    response2 = client.post(UNIT_URL, headers=headers_auth, json=data_2)
+    project2 = response2.json()['data']
+    project_id_2 = project2['projectId']
+
+    # delete project1 with compatible app - Positive Test
+    resp = client.delete(UNIT_URL+'?project_id='+str(project_id_1),headers=headers_auth)
+    assert resp.status_code == 201
+    assert resp.json()['message'] == f"Project with identity {project_id_1} deleted successfully"
+    # update compatibility of project 2
+    put_data = {
+    "projectId":project_id_2,
+    "compatibleWith": ["VachanAdmin"]
+    }
+    response2 = client.put(UNIT_URL, headers=headers_auth, json=put_data)
+
+    # delete project with incompatible app - Negative Test
+    resp = client.delete(UNIT_URL+'?project_id='+str(project_id_2),headers=headers_auth)
+    assert resp.status_code == 403
+    assert resp.json()['details'] == "Incompatible app"
 
 def test_get_filter_with_app_compatibility():
     '''Test  to filter with app compatibility'''
@@ -1374,20 +1416,49 @@ def test_get_filter_with_app_compatibility():
     "projectName": "Test project 1",
     "sourceLanguageCode": "hi",
     "targetLanguageCode": "ml",
-    "compatibleWith": "SanketMAST"
+    "compatibleWith": ["SanketMAST"]
     }
     data_2 = {
     "projectName": "Test project 2",
     "sourceLanguageCode": "hi",
     "targetLanguageCode": "ml"
     }
-    # Creating new project with compatible app - Negative Test
+    data_3 = {
+    "projectName": "Test project 3",
+    "sourceLanguageCode": "hi",
+    "targetLanguageCode": "ml",
+    "compatibleWith": ["SanketMAST","Autographa"]
+    }
+    # Creating new project with compatible app - Positive Test
     response1 = client.post(UNIT_URL, headers=headers_auth, json=data_1)
+    # Creating new project without mentioning compatible_with field - Positive test
     response2 = client.post(UNIT_URL, headers=headers_auth, json=data_2)
-    get_resp = client.get(UNIT_URL+'?compatible_with=SanketMAST',headers=headers_auth)
+    # Creating new project with multiple items in compatible_with field - Positive test
+    response3 = client.post(UNIT_URL, headers=headers_auth, json=data_3)
+   
+    # filtering with single app - positive test
+    get_resp = client.get(UNIT_URL + "?compatible_with=SanketMAST",headers=headers_auth)
     for item in get_resp.json():
         assert_positive_get(item)
-    assert len(get_resp.json()) == 2
-    assert get_resp.json()[0]['compatibleWith'] == 'SanketMAST'
-    assert get_resp.json()[1]['compatibleWith'] == 'SanketMAST'
-   
+    assert len(get_resp.json()) == 3
+    assert"SanketMAST" in  get_resp.json()[0]['compatibleWith']
+    assert"SanketMAST" in  get_resp.json()[1]['compatibleWith']
+    assert"SanketMAST" in  get_resp.json()[2]['compatibleWith']
+
+    #filtering with multiple apps - positive test
+    app_list = [schema_auth.App.SMAST.value, schema_auth.App.AG.value]
+    params = []
+    for app in app_list:
+        params.append(("compatible_with", app))
+    get_resp2 = client.get(UNIT_URL, params=params, headers=headers_auth)
+    for item in get_resp2.json():
+        assert_positive_get(item)
+    assert len(get_resp2.json()) == 1
+    for item in get_resp2.json():
+        assert_positive_get(item)
+        assert "SanketMAST" in item['compatibleWith']
+        assert "Autographa" in item['compatibleWith']
+
+    #filtering with app not in the list
+    get_resp = client.get(UNIT_URL + "?compatible_with=VachanAdmin",headers=headers_auth)
+    assert_not_available_content(get_resp)

--- a/app/test/test_smast_translation.py
+++ b/app/test/test_smast_translation.py
@@ -58,10 +58,9 @@ def test_get_tokens():
     assert_not_available_content(get_response1)
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id), headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     # after adding books
@@ -156,7 +155,7 @@ def test_tokenization_invalid():
     # non existant project
     response = client.get(UNIT_URL+"/tokens?project_id="+str(project_id+1),headers=headers_auth)
     assert response.status_code == 404
-    assert response.json()['details'] == "Project with id, %s, not found"%(project_id+1)
+    assert response.json()['details'] == "Project with id, %s, not present"%(project_id+1)
 
     #invalid book
     response = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+"&books=mmm"
@@ -200,11 +199,11 @@ def test_save_translation():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
 
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     resp = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
@@ -274,10 +273,10 @@ def test_save_translation_invalid():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     resp = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
@@ -356,10 +355,10 @@ def test_drafts():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     resp = client.get(UNIT_URL+"/tokens?project_id="+str(project_id)+
@@ -414,10 +413,10 @@ def test_get_token_sentences():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     resp = client.get("/v2/text/translate/token-based/project/tokens?project_id="+str(project_id)
@@ -484,10 +483,10 @@ def test_get_sentence():
     assert_not_available_content(response)
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     # before translation
@@ -565,10 +564,10 @@ def test_progress_n_suggestion():
     assert response.json()['suggestion'] == 0
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     # before translation
@@ -643,10 +642,10 @@ def test_get_versification():
         assert len(response.json()[key]) == 0
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     response = client.get(UNIT_URL+"/versification?project_id="+str(project_id)
@@ -679,10 +678,10 @@ def test_agmt_translation_access_rule_app():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     #get tokens
@@ -846,10 +845,10 @@ def test_data_updated_time():
 
     # Add book into empty project
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     # Get tokens
@@ -925,10 +924,10 @@ def test_agmt_translation_access_permissions():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "uploadedUSFMs":[bible_books['mat'], bible_books['mrk']]
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     resp = client.get("/v2/text/translate/token-based/project/tokens?project_id="+str(project_id)

--- a/app/test/test_smast_translation.py
+++ b/app/test/test_smast_translation.py
@@ -4,12 +4,13 @@ import re
 from math import ceil, floor
 from . import client
 from . import assert_input_validation_error, assert_not_available_content
-from .test_agmt_projects import bible_books, check_post as add_project
+from .test_agmt_projects import bible_books
 from .conftest import initial_test_users
 from . test_auth_basic import login,SUPER_PASSWORD,SUPER_USER
 
 
 UNIT_URL = '/v2/text/translate/token-based/project'
+PROJECT_URL = '/v2/text/translate/token-based/projects'
 headers = {"contentType": "application/json", "accept": "application/json","app":"SanketMAST"}
 headers_auth = {"contentType": "application/json",
                 "accept": "application/json",
@@ -48,7 +49,7 @@ def assert_positive_get_sentence(item):
 def test_get_tokens():
     '''Positive tests for tokenization process'''
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
-    resp = add_project(project_data)
+    resp = client.post(PROJECT_URL, headers=headers_auth, json=project_data)
     assert resp.json()['message'] == "Project created successfully"
     project_id = resp.json()['data']['projectId']
 
@@ -147,7 +148,8 @@ def test_get_tokens():
 
 def test_tokenization_invalid():
     '''Negative tests for tokenization'''
-    resp = add_project(project_data)
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    resp = client.post(PROJECT_URL, headers=headers_auth, json=project_data)
     assert resp.json()['message'] == "Project created successfully"
     project_id = resp.json()['data']['projectId']
 
@@ -192,7 +194,8 @@ def test_tokenization_invalid():
 
 def test_save_translation():
     '''Positive tests for PUT tokens method'''
-    resp = add_project(project_data)
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    resp = client.post(PROJECT_URL, headers=headers_auth, json=project_data)
     assert resp.json()['message'] == "Project created successfully"
     project_id = resp.json()['data']['projectId']
 
@@ -265,7 +268,8 @@ def test_save_translation():
 
 def test_save_translation_invalid():
     '''Negative tests for PUT tokens method'''
-    resp = add_project(project_data)
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    resp = client.post(PROJECT_URL, headers=headers_auth, json=project_data)
     assert resp.json()['message'] == "Project created successfully"
     project_id = resp.json()['data']['projectId']
 
@@ -346,7 +350,8 @@ def test_save_translation_invalid():
 
 def test_drafts():
     '''End to end test from tokenization to draft generation'''
-    resp = add_project(project_data)
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    resp = client.post(PROJECT_URL, headers=headers_auth, json=project_data)
     assert resp.json()['message'] == "Project created successfully"
     project_id = resp.json()['data']['projectId']
 
@@ -404,7 +409,7 @@ def test_drafts():
 def test_get_token_sentences():
     '''Check if draft-meta is properly segemneted according to specifed token occurence'''
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
-    resp = add_project(project_data)
+    resp = client.post(PROJECT_URL, headers=headers_auth, json=project_data)
     assert resp.json()['message'] == "Project created successfully"
     project_id = resp.json()['data']['projectId']
 
@@ -468,7 +473,8 @@ def test_get_token_sentences():
 
 def test_get_sentence():
     '''Positive test for agmt sentence/draft fetch API'''
-    resp = add_project(project_data)
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    resp = client.post(PROJECT_URL, headers=headers_auth, json=project_data)
     assert resp.json()['message'] == "Project created successfully"
     project_id = resp.json()['data']['projectId']
 
@@ -545,7 +551,8 @@ def test_get_sentence():
 
 def test_progress_n_suggestion():
     '''tests for project progress API of SanketMASTMT'''
-    resp = add_project(project_data)
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    resp = client.post(PROJECT_URL, headers=headers_auth, json=project_data)
     assert resp.json()['message'] == "Project created successfully"
     project_id = resp.json()['data']['projectId']
 
@@ -624,7 +631,8 @@ def test_progress_n_suggestion():
 
 def test_get_versification():
     '''Positive test for agmt sentence/draft fetch API'''
-    resp = add_project(project_data)
+    headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
+    resp = client.post(PROJECT_URL, headers=headers_auth, json=project_data)
     assert resp.json()['message'] == "Project created successfully"
     project_id = resp.json()['data']['projectId']
 
@@ -666,7 +674,7 @@ def test_agmt_translation_access_rule_app():
     """project translation related access rule and auth"""
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     #create a project
-    resp = add_project(project_data)
+    resp = client.post(PROJECT_URL, headers=headers_auth, json=project_data)
     assert resp.json()['message'] == "Project created successfully"
     project_id = resp.json()['data']['projectId']
 
@@ -830,7 +838,7 @@ def test_data_updated_time():
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
 
     #create an empty project
-    create_project_resp = add_project(project_data)
+    create_project_resp = client.post(PROJECT_URL, headers=headers_auth, json=project_data)
     assert create_project_resp.json()['message'] == "Project created successfully"
     project_id = create_project_resp.json()['data']['projectId']
     project_name =create_project_resp.json()['data']['projectName']
@@ -912,7 +920,7 @@ def test_agmt_translation_access_permissions():
     """test for access permission to project translation"""
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
     #create a project
-    resp = add_project(project_data)
+    resp = client.post(PROJECT_URL, headers=headers_auth, json=project_data)
     assert resp.json()['message'] == "Project created successfully"
     project_id = resp.json()['data']['projectId']
 

--- a/app/test/test_smast_translation2.py
+++ b/app/test/test_smast_translation2.py
@@ -45,10 +45,10 @@ def test_draft_update_positive():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "sentenceList":source_sentences
     }
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     resp = client.get(f"{UNIT_URL}/sentences?project_id={project_id}", headers=headers_auth)
@@ -155,11 +155,11 @@ def test_draft_update_negative():
 
     # upload source and repeat last action
     put_data_source = {
-        "projectId": project_id,
         "sentenceList":source_sentences
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data_source)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data_source)
     assert resp.json()['message'] == "Project updated successfully"
 
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
@@ -239,11 +239,11 @@ def test_empty_draft_initalization():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "sentenceList":source_sentences
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     # Ensure draft is set to ""
@@ -296,15 +296,15 @@ def test_draft_meta_validation():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "sentenceList":source_sentences
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     #Get suggestions
-    resp = client.put(f"/v2/text/translate/token-based/project/suggestions?project_id={project_id}&sentenceIdList=100", 
+    resp = client.put(f"/v2/text/translate/token-based/project/suggestions?project_id={project_id}&sentenceIdList=100",
         headers=headers_auth)
     assert resp.status_code == 201
     resp_draft_meta = resp.json()[0]['draftMeta']
@@ -334,11 +334,11 @@ def test_space_in_suggested_draft():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "sentenceList":source_sentences
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     # Add a gloss to ensure some suggestion in output
@@ -379,11 +379,11 @@ def test_delete_sentence():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "sentenceList":source_sentences
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTUser']['token']
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     # Check sentences are added
@@ -462,11 +462,11 @@ def test_restore_sentence():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "sentenceList":source_sentences
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     delete_resp = client.delete(f"{UNIT_URL}/sentences?project_id={project_id}&sentence_id=100",
             headers=headers_auth)
 
@@ -538,7 +538,6 @@ def test_suggestion_when_token_overlaps_confirmed_segment():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "sentenceList": [
             {
             "sentenceId": 57001002,
@@ -548,7 +547,8 @@ def test_suggestion_when_token_overlaps_confirmed_segment():
         ]
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['SanketMASTAdmin']['token']
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     # add a translation for just "not" when it occurs as "doesnot"
@@ -625,11 +625,11 @@ def test_draftmeta_validation():
     project_id = resp.json()['data']['projectId']
 
     put_data = {
-        "projectId": project_id,
         "sentenceList":source_sentences
     }
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgUser']['token']
-    resp = client.put("/v2/text/translate/token-based/projects", headers=headers_auth, json=put_data)
+    resp = client.put("/v2/text/translate/token-based/projects"+'?project_id='+str(project_id),\
+         headers=headers_auth, json=put_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     ## Spaces not accounted for

--- a/app/test/test_translation_workflow.py
+++ b/app/test/test_translation_workflow.py
@@ -391,31 +391,31 @@ def test_end_to_end_translation():
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
     resp = client.post(BASE_URL+"text/translate/token-based/projects", headers=headers_auth, json=project_post_data)
     assert resp.json()['message'] == "Project created successfully"
-    project_update_data['projectId'] = resp.json()['data']['projectId']
-    project_id = resp.json()['data']['projectId']
+    proj_id = resp.json()['data']['projectId']
 
-    resp = client.put(BASE_URL+"text/translate/token-based/projects", headers=headers_auth, json=project_update_data)
+    resp = client.put(BASE_URL+"text/translate/token-based/projects"+'?project_id='+str(proj_id), \
+      headers=headers_auth, json=project_update_data)
     assert resp.json()['message'] == "Project updated successfully"
 
     # tokenize
-    resp = client.get(BASE_URL+"text/translate/token-based/project/tokens?project_id="+str(project_id),headers=headers_auth)
+    resp = client.get(BASE_URL+"text/translate/token-based/project/tokens?project_id="+str(proj_id),headers=headers_auth)
     assert resp.status_code == 200
 
     # translate
-    resp = client.put(BASE_URL+"text/translate/token-based/project/tokens?project_id="+str(project_id),
+    resp = client.put(BASE_URL+"text/translate/token-based/project/tokens?project_id="+str(proj_id),
     	headers=headers_auth, json=token_update_data)
     assert resp.json()['message'] == "Token translations saved"
 
     # Additional user
     NEW_USER_ID = initial_test_users['AgUser']['test_user_id']
     headers_auth['Authorization'] = "Bearer"+" "+initial_test_users['AgAdmin']['token']
-    resp = client.post(BASE_URL+"text/translate/token-based/project/user?project_id="+str(project_id)+
+    resp = client.post(BASE_URL+"text/translate/token-based/project/user?project_id="+str(proj_id)+
     	"&user_id="+str(NEW_USER_ID), headers=headers_auth)
     assert resp.json()['message'] == "User added to project successfully"
 
-    user_data['project_id'] = project_id
     user_data['userId'] = NEW_USER_ID
-    resp = client.put(BASE_URL+"text/translate/token-based/project/user", headers=headers_auth, json=user_data)
+    resp = client.put(BASE_URL+"text/translate/token-based/project/user"'?project_id='+str(proj_id),\
+       headers=headers_auth, json=user_data)
     # print(resp.json())
     assert resp.json()['message'] == "User updated in project successfully"
 
@@ -432,7 +432,7 @@ def test_end_to_end_translation():
     
 
     # tokenize after adding token "परमेश्वर" via alignment
-    resp = client.put(BASE_URL+"text/translate/token-based/project/suggestions?project_id="+str(project_id)+
+    resp = client.put(BASE_URL+"text/translate/token-based/project/suggestions?project_id="+str(proj_id)+
         "&sentence_id_list=42001001",
     	headers=headers_auth)
     draft = resp.json()[0]['draft']

--- a/db/seed_DB.sql
+++ b/db/seed_DB.sql
@@ -118,6 +118,7 @@ CREATE TABLE public.translation_projects(
     created_at timestamp with time zone DEFAULT NOW(),
     last_updated_user text NULL,
     last_updated_at  timestamp with time zone DEFAULT NOW(),
+    compatible_with text,
     UNIQUE(project_name, created_user)
 );
 ALTER SEQUENCE public.translation_projects_project_id_seq RESTART WITH 100000;

--- a/db/seed_DB.sql
+++ b/db/seed_DB.sql
@@ -118,7 +118,7 @@ CREATE TABLE public.translation_projects(
     created_at timestamp with time zone DEFAULT NOW(),
     last_updated_user text NULL,
     last_updated_at  timestamp with time zone DEFAULT NOW(),
-    compatible_with text,
+    compatible_with text[],
     UNIQUE(project_name, created_user)
 );
 ALTER SEQUENCE public.translation_projects_project_id_seq RESTART WITH 100000;


### PR DESCRIPTION
- #442 
- **has database change**
- **Moved `project_id` from body param to query param in PUT projects and PUT user APIs**
- App compatibility check added in following APIs
   - PUT ,POST,DELETE of `/v2/text/translate/token-based/projects`
   - PUT,POST,DELETE of `/v2/text/translate/token-based/project/user`
   - GET,PUT of `/v2/text/translate/token-based/project/tokens`
   - GET of `/v2/text/translate/token-based/project/token-translations`
   - GET of `/v2/text/translate/token-based/project/token-sentences`
   - GET,PUT of `/v2/text/translate/token-based/project/draft`
   - GET,DELETE of `/v2/text/translate/token-based/project/sentences`
   - GET `/v2/text/translate/token-based/project/progress`
   - GET `/v2/text/translate/token-based/project/versification`
   - PUT `/v2/text/translate/token-based/suggestions`
