### PR TITLE
Use ofelia and pg_dump for backup of postgres DBs

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,6 +14,11 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=md5
     volumes: 
       - kratos-postgres-vol:/var/lib/postgresql/data
+      - kratos-db-backup:/var/backups:rw
+    labels:
+      ofelia.enabled: "true"
+      ofelia.job-exec.kratos-backup.schedule: "0 0 1 * * *" #"Takes a single dump within the db container every day at 01:00 am"
+      ofelia.job-exec.kratos-backup.command: "pg_dump --dbname=postgresql://$VACHAN_KRATOS_DB_USER:$VACHAN_KRATOS_DB_PASSWORD@localhost:5432/$VACHAN_KRATOS_DB_NAME  --file=/var/backups/kratos_db_backup_latest.sql"
     networks:
       - VE-network
 
@@ -94,6 +99,11 @@ services:
      - vachan-db-vol:/var/lib/postgresql/data
      - ../db/csvs:/csvs
      - ../db/seed_DB.sql:/docker-entrypoint-initdb.d/seed_DB.sql
+     - vachan-db-backup:/var/backups:rw
+    labels:
+      ofelia.enabled: "true"
+      ofelia.job-exec.vachan-backup.schedule: "0 0 0 * * *" #"Takes a single dump within the db container every day at 00:00 am"
+      ofelia.job-exec.vachan-backup.command: "pg_dump --dbname=postgresql://$VACHAN_POSTGRES_USER:$VACHAN_POSTGRES_PASSWORD@localhost:5432/$VACHAN_POSTGRES_DATABASE  --file=/var/backups/vachan_db_backup_latest.sql"
 
  #vachan-api app
  vachan-api:
@@ -249,90 +259,52 @@ services:
   networks:
    - VE-network
  
- # offen backup
- offen-backup_vachan_daily: &backup_service
-  image: offen/docker-volume-backup:latest
-  restart: always
-  environment: &backup_environment
-      #Daily 00 : 00
-      BACKUP_CRON_EXPRESSION: "0 0 * * *"
-      BACKUP_FILENAME: backup-vachan-daily-%Y-%m-%dT%H-%M-%S.tar.gz
-      BACKUP_SOURCES: /docker_vachan-db-vol
-      BACKUP_PRUNING_PREFIX: backup-vachan-daily-
-      BACKUP_RETENTION_DAYS: 5
-  depends_on:
-   - vachan-db
-  volumes:
-      - vachan-db-vol:/docker_vachan-db-vol:ro
-      # - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /var/lib/backups:/archive
-  profiles:
-   - deployment
-  networks:
-   - VE-network
- 
- offen-backup_vachan_week:
-  <<: *backup_service
-  environment:
-      <<: *backup_environment
-      # SAT 00 : 00
-      BACKUP_CRON_EXPRESSION: "0 0 * * 6"
-      BACKUP_FILENAME: backup-vachan-week-%Y-%m-%dT%H-%M-%S.tar.gz
-      BACKUP_SOURCES: /docker_vachan-db-vol
-      BACKUP_PRUNING_PREFIX: backup-vachan-week-
-      BACKUP_RETENTION_DAYS: 49
-  depends_on:
-   - vachan-db
-  volumes:
-      - vachan-db-vol:/docker_vachan-db-vol:ro
-      # - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /var/lib/backups:/archive
-  profiles:
-   - deployment
-  networks:
-   - VE-network
 
- offen-backup_vachan_month:
-  <<: *backup_service
-  environment:
-      <<: *backup_environment
-      # monthly 28th day 00 : 00
-      BACKUP_CRON_EXPRESSION: "0 0 28 * *"
-      BACKUP_FILENAME: backup-vachan-month-%Y-%m-%dT%H-%M-%S.tar.gz
-      BACKUP_SOURCES: /docker_vachan-db-vol
-      BACKUP_PRUNING_PREFIX: backup-vachan-month-
-      BACKUP_RETENTION_DAYS: 365
-  depends_on:
-   - vachan-db
-  volumes:
-      - vachan-db-vol:/docker_vachan-db-vol:ro
-      # - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /var/lib/backups:/archive
-  profiles:
-   - deployment
-  networks:
-   - VE-network
- 
- offen-backup_vachan_year:
-  <<: *backup_service
-  environment:
-      <<: *backup_environment
-      # yearly DEC 31 day 00 : 00
-      BACKUP_CRON_EXPRESSION: "0 0 31 12 *"
-      BACKUP_FILENAME: backup-vachan-year-%Y-%m-%dT%H-%M-%S.tar.gz
-      BACKUP_SOURCES: /docker_vachan-db-vol
-      BACKUP_PRUNING_PREFIX: backup-vachan-year-
-      BACKUP_RETENTION_DAYS: 2555
-  depends_on:
-   - vachan-db
-  volumes:
-      - vachan-db-vol:/docker_vachan-db-vol:ro
-      # - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /var/lib/backups:/archive
-  profiles:
-   - deployment
-  networks:
-   - VE-network
+ ofelia-scheduler:
+    image: mcuadros/ofelia:v0.3.7
+    depends_on:
+      - kratos-postgresd
+      - vachan-db
+    command: daemon --docker
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - kratos-db-backup:/var/backups/kratos:ro
+      - vachan-db-backup:/var/backups/vachan:ro
+      - /var/lib/backups:/var/backup-copies/:rw
+      - logs-vol:/app/logs
+    environment:
+      - TZ=${TIMEZONE:-Asia/Calcutta}
+    labels:
+      ofelia.job-local.copy-vachan-backup-daily.schedule: "0 0 3 * * *" # Copies latest dump from DB container every day at 03:00 am
+      ofelia.job-local.copy-vachan-backup-daily.command: sh -c "cp /var/backups/vachan/vachan_db_backup_latest.sql /var/backup-copies/vachan_db_backup_daily_`date +%Y-%m-%d_%H_%M_%S`.sql && echo `date`':Daily backup successful(vachan-db)' >> /app/logs/backup.log || echo `date`':Daily backup failed(vachan)' >> /app/logs/backup.log"
+      ofelia.job-local.prune-vachan-daily-backup.schedule: "0 0 0 * * *" # Retains only latest 7 of the daily backups 
+      ofelia.job-local.prune-vachan-daily-backup.command: sh -c "ls -tr /var/backup-copies/vachan_db_backup_daily* | head -n -7 |  xargs rm -f -- && echo `date`':Daily Prune successful(vachan-db)' >> /app/logs/backup.log || echo `date`':Daily Prune failed(vachan)' >> /app/logs/backup.log"
+      ofelia.job-local.copy-vachan-backup-weekly.schedule: "0 0 3 ? * SUN" # Copies latest dump on every sunday 03:00 am
+      ofelia.job-local.copy-vachan-backup-weekly.command: sh -c "cp /var/backups/vachan/vachan_db_backup_latest.sql /var/backup-copies/vachan_db_backup_weekly_`date +%Y-%m-%d_%H_%M_%S`.sql && echo `date`':Weekly backup successful(vachan-db)' >> /app/logs/backup.log || echo `date`':Weekly backup failed(vachan)' >> /app/logs/backup.log"
+      ofelia.job-local.prune-vachan-weekly-backup.schedule: "0 0 0 ? * SUN" # Retains only latest 4 of the weekly backups
+      ofelia.job-local.prune-vachan-weekly-backup.command: sh -c "ls -tr /var/backup-copies/vachan_db_backup_weekly* | head -n -4 |  xargs rm -f -- && echo `date`':Weekly Prune successful(vachan-db)' >> /app/logs/backup.log || echo `date`':Weekly Prune failed(vachan)' >> /app/logs/backup.log"
+      ofelia.job-local.copy-vachan-backup-monthly.schedule: "0 0 3 1 * *" # Copies latest dump on first day of every month
+      ofelia.job-local.copy-vachan-backup-monthly.command: sh -c "cp /var/backups/vachan/vachan_db_backup_latest.sql /var/backup-copies/vachan_db_backup_monthly_`date +%Y-%m-%d_%H_%M_%S`.sql && echo `date`':Monthly backup successful(vachan-db)' >> /app/logs/backup.log || echo `date`':Monthly backup failed(vachan)' >> /app/logs/backup.log"
+      ofelia.job-local.prune-vachan-monthly-backup.schedule: "0 0 0 1 * *" # Retains only latest 12 of the montly dumps
+      ofelia.job-local.prune-vachan-monthly-backup.command: sh -c "ls -tr /var/backup-copies/vachan_db_backup_monthly* | head -n -12 |  xargs rm -f -- && echo `date`':Monthly Prune successful(vachan-db)' >> /app/logs/backup.log || echo `date`':Monthly Prune failed(vachan)' >> /app/logs/backup.log"
+      ofelia.job-local.copy-vachan-backup-yearly.schedule: "0 0 3 * JAN *" # Copies latest dump on first day of every year
+      ofelia.job-local.copy-vachan-backup-yearly.command: sh -c "cp /var/backups/vachan/vachan_db_backup_latest.sql /var/backup-copies/vachan_db_backup_yearly_`date +%Y-%m-%d_%H_%M_%S`.sql && echo `date`':Yearly backup successful(vachan-db)' >> /app/logs/backup.log || echo `date`':Yearly backup failed(vachan)' >> /app/logs/backup.log"
+      ofelia.job-local.copy-kratos-backup-daily.schedule: "0 0 4 * * *" # Copies latest dump from DB container every day at 04:00 am
+      ofelia.job-local.copy-kratos-backup-daily.command: sh -c "cp /var/backups/kratos/kratos_db_backup_latest.sql /var/backup-copies/kratos_db_backup_daily_`date +%Y-%m-%d_%H_%M_%S`.sql && echo `date`':Daily backup successful(kratos)' >> /app/logs/backup.log || echo `date`':Daily backup failed(kratos)' >> /app/logs/backup.log"
+      ofelia.job-local.prune-kratos-daily-backup.schedule: "0 0 1 * * *" # Retains only latest 7 of the daily backups 
+      ofelia.job-local.prune-kratos-daily-backup.command: sh -c "ls -tr /var/backup-copies/kratos_db_backup_daily* | head -n -7 |  xargs rm -f -- && echo `date`':Daily Prune successful(kratos)' >> /app/logs/backup.log || echo `date`':Daily Prune failed(kratos)' >> /app/logs/backup.log"
+      ofelia.job-local.copy-kratos-backup-weekly.schedule: "0 0 4 ? * SUN" # Copies latest dump on every sunday 04:00 am
+      ofelia.job-local.copy-kratos-backup-weekly.command: sh -c "cp /var/backups/kratos/kratos_db_backup_latest.sql /var/backup-copies/kratos_db_backup_weekly_`date +%Y-%m-%d_%H_%M_%S`.sql && echo `date`':Weekly backup successful(kratos)' >> /app/logs/backup.log || echo `date`':Weekly backup failed(kratos)' >> /app/logs/backup.log"
+      ofelia.job-local.prune-kratos-weekly-backup.schedule: "0 1 0 ? * SUN" # Retains only latest 4 of the weekly backups
+      ofelia.job-local.prune-kratos-weekly-backup.command: sh -c "ls -tr /var/backup-copies/kratos_db_backup_weekly* | head -n -4 |  xargs rm -f -- && echo `date`':Weekly Prune successful(kratos)' >> /app/logs/backup.log || echo `date`':Weekly Prune failed(kratos)' >> /app/logs/backup.log"
+      ofelia.job-local.copy-kratos-backup-monthly.schedule: "0 0 4 1 * *" # Copies latest dump on first day of every month
+      ofelia.job-local.copy-kratos-backup-monthly.command: sh -c "cp /var/backups/kratos/kratos_db_backup_latest.sql /var/backup-copies/kratos_db_backup_monthly_`date +%Y-%m-%d_%H_%M_%S`.sql && echo `date`':Monthly backup successful(kratos)' >> /app/logs/backup.log || echo `date`':Monthly backup failed(kratos)' >> /app/logs/backup.log"
+      ofelia.job-local.prune-kratos-monthly-backup.schedule: "0 0 1 1 * *" # Retains only latest 12 of the montly dumps
+      ofelia.job-local.prune-kratos-monthly-backup.command: sh -c "ls -tr /var/backup-copies/kratos_db_backup_monthly* | head -n -12 |  xargs rm -f -- && echo `date`':Monthly Prune successful(kratos)' >> /app/logs/backup.log || echo `date`':Monthly Prune failed(kratos)' >> /app/logs/backup.log"
+      ofelia.job-local.copy-kratos-backup-yearly.schedule: "0 0 4 * JAN *" # Copies latest dump on first day of every year
+      ofelia.job-local.copy-kratos-backup-yearly.command: sh -c "cp /var/backups/kratos/kratos_db_backup_latest.sql /var/backup-copies/kratos_db_backup_yearly_`date +%Y-%m-%d_%H_%M_%S`.sql && echo `date`':Yearly backup successful(kratos)' >> /app/logs/backup.log || echo `date`':Yearly backup failed(kratos)' >> /app/logs/backup.log"
+    networks:
+     - VE-network
 
  #redis caching DB
  redis:
@@ -378,3 +350,5 @@ volumes:
   redisinsight:
   kratos-postgres-vol:
   logs-test-vol:
+  vachan-db-backup:
+  kratos-db-backup:

--- a/docs/Volume-backup.md
+++ b/docs/Volume-backup.md
@@ -1,55 +1,34 @@
 # Backing up DB Volumes ( Vacahn , Kratos )
 
-[Offen docker-volume-backup ](https://github.com/offen/docker-volume-backup) is used for the periodical Backing up of database volumes of Vachan App and Kratos.
-
-## Servers
-
-- vachan App Production Server ( Termed as **Production-server**)
-- Internal Backup server (Termed as **DODB-BKP**)
+Uses [ofelia scheduler](https://hub.docker.com/r/mcuadros/ofelia/).
+All settings are done in the docker-compose alone, and no need to do any configurations on the deployed server to enable this.
 
 ## Current Backing Up process
 
-There are 2 backup process implemented. The processes are setup independenly, one working on the backup-volumes created by the other. Servers are communicated via RSA. In current implementation DODB-BKP have access to production-server to sync the backups via RSA.
+Vachan db backups schedule
+- Takes a single dump within the vachan-db postgres container every day at 00:00 am, using pg_dump
+- Deletes older backups at 00:00 am from /var/lib/backups 
+  - Retains only latest 7 of the daily backups
+  - Retains only latest 4 of the weekly backups
+  - Retains only latest 12 of the montly dumps
+- Copies latest dump from DB container to /var/lib/backups at 03:00 am
+  - On every day as daily backup
+  - On sundays as weekly backup
+  - On first day of every month, as mothly backup
+  - On first day of each year, as yearly backup
+- Logs the success or failure status of copying and deleting to backup.log in logs volume, shared by other logs like webserver, vachan-api etc
 
-### Backup - 1
+Kratos db backup schedule
+- Takes a single dump within the kratos-postgresd container every day at 01:00 am, using pg_dump
+- Deletes older backups at 01:00 am from /var/lib/backups 
+  - Retains only latest 7 of the daily backups
+  - Retains only latest 4 of the weekly backups
+  - Retains only latest 12 of the montly dumps
+- Copies latest dump from DB container to /var/lib/backups at 04:00 am
+  - On every day as daily backup
+  - On sundays as weekly backup
+  - On first day of every month, as mothly backup
+  - On first day of each year, as yearly backup
+- Logs the success or failure status of copying and deleting to backup.log in logs volume
 
-- Periodical backup of docker volumes are created in the Production-server by Offen.
-- The offen backup containers are set in the [Production-Deploy](https://github.com/Bridgeconn/vachan-api/blob/version-2/docker/production-deploy.yml) , [Kratos-Database](https://github.com/Bridgeconn/vachan-api/blob/version-2/docker/Kratos_config/database.yml) yml.
-- Offen will be responsible for all features related of backingup like timely backup, cleanup old backups etc.
-- Offen backup is at the directory **/var/lib/backups** in the production-server
-- offen backup and prune frequencies are in the yml files.
-
-### Backup -2
-
-Second process is an internal backing up to DODB-BKP of same backup volumes created by the offen in the production-server
-
-- Backup-2 is basically a syncing of backup directory of production-server to DODB-BKP
-- cronjob and rsync features are used for backup-2
-- cronjob structure
-
-```
-*        *        *        *        *
-minute   hour     day      month    WeekDay
-```
-
-- rsync format example
-
-```
-rsync [options] "source" "Destination"
-```
-
-- In the current implementation cronjob is set in the DODB-BKP server and it read and sync the production-server /var/lib/backups every day at a time (eg : 2:00 am).
-
-- syncing cronjob code example
-
-```
-0 2 * * * rsync -au --delete "username@IP:/var/lib/backups/" "/var/dodbbkp"
-```
-
-- cronjob can be added/modified by the command
-
-```
-crontab -e
-
-edit crontab , save and exit
-```
+:warning: This only copies the backups to the folder /val/lib/backups in the same server where app is deployed. Not moving them to a different server.


### PR DESCRIPTION
- Attempting a fix for #431 
- Uses normal pg_dump for backup instead of copying the data directory
- Keep cron job settings for backup within docker-compose itself, eliminating the need for any additional setup when deploying
- Uses [ofelia scheduler](https://hub.docker.com/r/mcuadros/ofelia/) for cron like scheduling.
- Updates the documentation as per the changes
- A simple logging for backup also implemented

## Current Backing Up process

Vachan db backups schedule
- Takes a single dump within the vachan-db postgres container every day at 00:00 am, using pg_dump
- Deletes older backups at 00:00 am from /var/lib/backups 
  - Retains only latest 7 of the daily backups
  - Retains only latest 4 of the weekly backups
  - Retains only latest 12 of the montly dumps
- Copies latest dump from DB container to /var/lib/backups at 03:00 am
  - On every day as daily backup
  - On sundays as weekly backup
  - On first day of every month, as mothly backup
  - On first day of each year, as yearly backup
- Logs the success or failure status of copying and deleting to backup.log in logs volume, shared by other logs like webserver, vachan-api etc

Kratos db backup schedule
- Takes a single dump within the kratos-postgresd container every day at 01:00 am, using pg_dump
- Deletes older backups at 01:00 am from /var/lib/backups 
  - Retains only latest 7 of the daily backups
  - Retains only latest 4 of the weekly backups
  - Retains only latest 12 of the montly dumps
- Copies latest dump from DB container to /var/lib/backups at 04:00 am
  - On every day as daily backup
  - On sundays as weekly backup
  - On first day of every month, as mothly backup
  - On first day of each year, as yearly backup
- Logs the success or failure status of copying and deleting to backup.log in logs volume

:warning: This only copies the backups to the folder /val/lib/backups on the same server where app is deployed. Not moving them to a different server.

