### PR TITLE
Add SSL setup script for Dockerized Nginx with Let's Encrypt

### DIFF
--- a/docker/auto_ssl_script.sh
+++ b/docker/auto_ssl_script.sh
@@ -4,99 +4,70 @@
 # Developer Details
 # ------------------------------------------------------------------------------
 # Name: Uday Kumar
-# Contact: [uday.kumar@bridgeconn.com](uday.kumar@bridgeconn.com)
+# Contact: uday.kumar@bridgeconn.com
 # Date: 21 Nov 2023
-# Description: This script sets up and manages a Dockerized Nginx environment 
-# with Let's Encrypt SSL, including automatic certificate renewal.
+# Description: This script sets up and manages Let's Encrypt SSL, including automatic certificate renewal.
 # ------------------------------------------------------------------------------
 
-# Environment variables
-NGINX_CONTAINER_NAME="${NGINX_CONTAINER_NAME}"
-DOMAIN_NAME="${VACHAN_DOMAIN}"
-EMAIL="${EMAIL}"
 
-# Can change as per host letsencrypt path
-CERT_PATH="/etc/letsencrypt/."
-DOCKER_VOLUME_PATH="./certbot/conf/"
+# Load environment variables
+if [ -f prod.env ]; then
+    source prod.env
+else
+    echo "prod.env file not found"
+    exit 1
+fi
 
-# Stop Nginx container
-stop_nginx_container() {
-    echo "Stopping Nginx container: $1..."
-    docker stop "$1" || { echo "Failed to stop Nginx container"; exit 1; }
-}
+# Configuration variables
+NGINX_CONTAINER_NAME="docker-web-server-with-cert-1"
+SSL_CERTS_DIR="/certbot/conf"
+WEBROOT_DIR="/certbot/www"
 
-# Check and free up port 80
-free_up_port_80() {
-    echo "Checking port 80..."
-    PORT_80_PID=$(lsof -t -i:80)
-    if [ ! -z "$PORT_80_PID" ]; then
-        echo "Port 80 is in use by PID $PORT_80_PID. Killing the process..."
-        kill -9 "$PORT_80_PID" || { echo "Failed to kill process on port 80"; exit 1; }
+# Generate SSL certificates
+generate_certificates() {
+    echo "Generating SSL certificates for $DOMAIN..."
+
+    docker run --rm -it \
+        -v "$(pwd)${SSL_CERTS_DIR}:/etc/letsencrypt" \
+        -p 80:80 \
+        certbot/certbot certonly --standalone \
+        --email "${CERTBOT_EMAIL}" --agree-tos --no-eff-email \
+        -d "${VACHAN_DOMAIN}" --non-interactive --verbose
+
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to generate SSL certificates."
+        exit 1
     fi
 }
 
-# Install Nginx
-install_nginx() {
-    if ! command -v nginx &> /dev/null; then
-        echo "Nginx not found, installing..."
-        apt-get update && apt-get install -y nginx || { echo "Failed to install Nginx"; exit 1; }
+# Renew SSL certificates
+renew_certificates() {
+    echo "Renewing SSL certificates for $DOMAIN..."
+
+    docker run --rm \
+        -v "$(pwd)${SSL_CERTS_DIR}:/etc/letsencrypt" \
+        certbot/certbot renew --non-interactive --verbose
+
+    if [ $? -ne 0 ]; then
+        echo "Error: Failed to renew SSL certificates."
+        exit 1
     fi
 }
 
-# Install Certbot
-install_certbot() {
-    if ! command -v certbot &> /dev/null; then
-        echo "Certbot not found, installing..."
-        apt-get update && snap install certbot --classic || { echo "Failed to install Certbot"; exit 1; }
-    fi
-}
-
-# Create SSL certificate
-create_ssl_certificate() {
-    local domain="$1"
-    local email="$2"
-    echo "Creating SSL certificate for $domain..."
-    certbot certonly --standalone -d "$domain" --non-interactive --agree-tos --email "$email" || { echo "Failed to create SSL certificate"; exit 1; }
-}
-
-# Copy SSL certificate from host to Docker volume
-copy_ssl_certificate() {
-    local cert_path="$1"
-    local docker_volume_path="$2"
-    echo "Copying SSL certificate to Docker volume..."
-    cp -r "$cert_path" "$docker_volume_path" || { echo "Failed to copy SSL certificate"; exit 1; }
-}
-
-# Stop or remove Nginx on host
-stop_or_remove_nginx_host() {
-    echo "Stopping or removing Nginx on host..."
-    systemctl stop nginx || { echo "Failed to stop Nginx on host"; exit 1; }
-    # Remove Nginx instead of just stopping it
-    # apt-get remove -y nginx || { echo "Failed to remove Nginx from host"; exit 1; }
-}
-
-# Start Nginx container
+# Restart Nginx container
 start_nginx_container() {
-    echo "Starting Nginx container: $1..."
-    docker start "$1" || { echo "Failed to start Nginx container"; exit 1; }
-}
-
-# Setup automatic renewal of SSL certificate
-setup_automatic_ssl_renewal() {
-    echo "Setting up automatic SSL certificate renewal..."
-    (crontab -l 2>/dev/null; echo "0 3 * * * certbot renew --quiet --renew-hook 'docker restart $NGINX_CONTAINER_NAME'") | crontab - || { echo "Failed to setup automatic SSL certificate renewal"; exit 1; }
+    echo "Starting Nginx container: ${NGINX_CONTAINER_NAME}..."
+    docker restart "${NGINX_CONTAINER_NAME}" || { echo "Failed to start Nginx container"; exit 1; }
 }
 
 
-# Main execution
-stop_nginx_container "$NGINX_CONTAINER_NAME"
-free_up_port_80
-install_nginx
-install_certbot
-create_ssl_certificate "$DOMAIN_NAME" "$EMAIL"
-copy_ssl_certificate "$CERT_PATH" "$DOCKER_VOLUME_PATH"
-setup_automatic_ssl_renewal
-stop_or_remove_nginx_host
-start_nginx_container "$NGINX_CONTAINER_NAME"
+# Execute the functions
+if [ ! -e "${SSL_CERTS_DIR}/live/${DOMAIN}/fullchain.pem" ]; then
+    generate_certificates
+    start_nginx_container
+else
+    renew_certificates
+fi
+
 
 echo "Script completed successfully."

--- a/docker/auto_ssl_script.sh
+++ b/docker/auto_ssl_script.sh
@@ -88,7 +88,6 @@ setup_automatic_ssl_renewal() {
 }
 
 
-
 # Main execution
 stop_nginx_container "$NGINX_CONTAINER_NAME"
 free_up_port_80
@@ -97,6 +96,7 @@ install_certbot
 create_ssl_certificate "$DOMAIN_NAME" "$EMAIL"
 copy_ssl_certificate "$CERT_PATH" "$DOCKER_VOLUME_PATH"
 setup_automatic_ssl_renewal
+stop_or_remove_nginx_host
 start_nginx_container "$NGINX_CONTAINER_NAME"
 
 echo "Script completed successfully."

--- a/docker/auto_ssl_script.sh
+++ b/docker/auto_ssl_script.sh
@@ -67,6 +67,14 @@ copy_ssl_certificate() {
     cp -r "$cert_path" "$docker_volume_path" || { echo "Failed to copy SSL certificate"; exit 1; }
 }
 
+# Stop or remove Nginx on host
+stop_or_remove_nginx_host() {
+    echo "Stopping or removing Nginx on host..."
+    systemctl stop nginx || { echo "Failed to stop Nginx on host"; exit 1; }
+    # Remove Nginx instead of just stopping it
+    # apt-get remove -y nginx || { echo "Failed to remove Nginx from host"; exit 1; }
+}
+
 # Start Nginx container
 start_nginx_container() {
     echo "Starting Nginx container: $1..."
@@ -78,6 +86,8 @@ setup_automatic_ssl_renewal() {
     echo "Setting up automatic SSL certificate renewal..."
     (crontab -l 2>/dev/null; echo "0 3 * * * certbot renew --quiet --renew-hook 'docker restart $NGINX_CONTAINER_NAME'") | crontab - || { echo "Failed to setup automatic SSL certificate renewal"; exit 1; }
 }
+
+
 
 # Main execution
 stop_nginx_container "$NGINX_CONTAINER_NAME"

--- a/docker/auto_ssl_script.sh
+++ b/docker/auto_ssl_script.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# ------------------------------------------------------------------------------
+# Developer Details
+# ------------------------------------------------------------------------------
+# Name: Uday Kumar
+# Contact: [uday.kumar@bridgeconn.com](uday.kumar@bridgeconn.com)
+# Date: 21 Nov 2023
+# Description: This script sets up and manages a Dockerized Nginx environment 
+# with Let's Encrypt SSL, including automatic certificate renewal.
+# ------------------------------------------------------------------------------
+
+# Environment variables
+NGINX_CONTAINER_NAME="${NGINX_CONTAINER_NAME}"
+DOMAIN_NAME="${VACHAN_DOMAIN}"
+EMAIL="${EMAIL}"
+
+# Can change as per host letsencrypt path
+CERT_PATH="/etc/letsencrypt/."
+DOCKER_VOLUME_PATH="./certbot/conf/"
+
+# Stop Nginx container
+stop_nginx_container() {
+    echo "Stopping Nginx container: $1..."
+    docker stop "$1" || { echo "Failed to stop Nginx container"; exit 1; }
+}
+
+# Check and free up port 80
+free_up_port_80() {
+    echo "Checking port 80..."
+    PORT_80_PID=$(lsof -t -i:80)
+    if [ ! -z "$PORT_80_PID" ]; then
+        echo "Port 80 is in use by PID $PORT_80_PID. Killing the process..."
+        kill -9 "$PORT_80_PID" || { echo "Failed to kill process on port 80"; exit 1; }
+    fi
+}
+
+# Install Nginx
+install_nginx() {
+    if ! command -v nginx &> /dev/null; then
+        echo "Nginx not found, installing..."
+        apt-get update && apt-get install -y nginx || { echo "Failed to install Nginx"; exit 1; }
+    fi
+}
+
+# Install Certbot
+install_certbot() {
+    if ! command -v certbot &> /dev/null; then
+        echo "Certbot not found, installing..."
+        apt-get update && snap install certbot --classic || { echo "Failed to install Certbot"; exit 1; }
+    fi
+}
+
+# Create SSL certificate
+create_ssl_certificate() {
+    local domain="$1"
+    local email="$2"
+    echo "Creating SSL certificate for $domain..."
+    certbot certonly --standalone -d "$domain" --non-interactive --agree-tos --email "$email" || { echo "Failed to create SSL certificate"; exit 1; }
+}
+
+# Copy SSL certificate from host to Docker volume
+copy_ssl_certificate() {
+    local cert_path="$1"
+    local docker_volume_path="$2"
+    echo "Copying SSL certificate to Docker volume..."
+    cp -r "$cert_path" "$docker_volume_path" || { echo "Failed to copy SSL certificate"; exit 1; }
+}
+
+# Start Nginx container
+start_nginx_container() {
+    echo "Starting Nginx container: $1..."
+    docker start "$1" || { echo "Failed to start Nginx container"; exit 1; }
+}
+
+# Setup automatic renewal of SSL certificate
+setup_automatic_ssl_renewal() {
+    echo "Setting up automatic SSL certificate renewal..."
+    (crontab -l 2>/dev/null; echo "0 3 * * * certbot renew --quiet --renew-hook 'docker restart $NGINX_CONTAINER_NAME'") | crontab - || { echo "Failed to setup automatic SSL certificate renewal"; exit 1; }
+}
+
+# Main execution
+stop_nginx_container "$NGINX_CONTAINER_NAME"
+free_up_port_80
+install_nginx
+install_certbot
+create_ssl_certificate "$DOMAIN_NAME" "$EMAIL"
+copy_ssl_certificate "$CERT_PATH" "$DOCKER_VOLUME_PATH"
+setup_automatic_ssl_renewal
+start_nginx_container "$NGINX_CONTAINER_NAME"
+
+echo "Script completed successfully."

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -267,25 +267,29 @@ services:
   volumes:
    - ./nginx/prod/app.conf.template:/etc/nginx/templates/default.conf.template:ro
    - ./certbot/www:/var/www/certbot/:ro
-   - ./certbot/conf/:/etc/nginx/ssl/:ro
+   - ./certbot/conf:/etc/nginx/certs/:ro
    - logs-vol:/var/log/nginx/
   environment:
-    - VACHAN_DOMAIN=${VACHAN_DOMAIN}
+   - VACHAN_DOMAIN=${VACHAN_DOMAIN}
   profiles:
    - deployment
   networks:
    - VE-network
 
  certbot:
-  image: certbot/certbot:latest
+  image: certbot/certbot
   volumes:
-   - ./certbot/www/:/var/www/certbot/:rw
-   - ./certbot/conf/:/etc/letsencrypt/:rw
+    - ./certbot/conf:/etc/letsencrypt
+    - ./auto_ssl_script.sh:/auto_ssl_script.sh
   profiles:
    - deployment
+  entrypoint: /bin/sh -c '
+    while :; do
+      /auto_ssl_script.sh;
+      sleep 80d;
+    done;'
   networks:
-   - VE-network
- 
+   - VE-network 
 
  ofelia-scheduler:
     image: mcuadros/ofelia:v0.3.7

--- a/docker/nginx/prod/app.conf.template
+++ b/docker/nginx/prod/app.conf.template
@@ -33,8 +33,8 @@ server {
     proxy_connect_timeout 300;
     proxy_send_timeout 300;
 
-    ssl_certificate /etc/nginx/ssl/live/${VACHAN_DOMAIN}/fullchain.pem;
-    ssl_certificate_key /etc/nginx/ssl/live/${VACHAN_DOMAIN}/privkey.pem;
+    ssl_certificate /etc/nginx/certs/live/${VACHAN_DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/live/${VACHAN_DOMAIN}/privkey.pem;
  
 
     location /graphql/ {


### PR DESCRIPTION
This commit introduces a new shell script for setting up and managing a Dockerised Nginx environment. Key features include:

- Stopping/starting Nginx container
- Freeing up port 80 on the host
- Installing Nginx and Certbot if not present
- Generating Let's Encrypt SSL certificates
- Setting up automatic SSL certificate renewal
- Copying SSL certificates to a specified Docker volume

The script is intended to streamline the deployment and maintenance of secure Nginx setups in Docker environments.